### PR TITLE
Change links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,7 +5,7 @@ about: Report a bug in the project
 
 <!-- Thank you for your contribution. Before you submit the issue:
 1. Search open and closed issues for duplicates.
-2. Read the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
+2. Read the contributing guidelines: https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md
 -->
 
 **Description**

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -5,7 +5,7 @@ about: Suggest an improvement to the project
 
 <!-- Thank you for your contribution. Before you submit the issue:
 1. Search open and closed issues for duplicates.
-2. Read the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
+2. Read the contributing guidelines: https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md
 -->
 
 **Description**

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,5 +1,5 @@
 <!--   Thank you for your contribution. Before you submit the pull request:
-1. Follow the contributing guidelines: https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md
+1. Follow the contributing guidelines: https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md
 2. Test your changes and attach their results to the pull request.
 3. Update any relevant documentation.
 4. Sign the Contributor License Agreement.

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -17,5 +17,5 @@ jobs:
           cx_client_id: ${{ secrets.CXONE_CLIENT_ID }}
           cx_client_secret: ${{ secrets.CXONE_CLIENT_SECRET }}
           branch: ${{ github.ref_name }}
-          additional_params: "--async --scan-types sast -s https://github.com/SAP/luigi.git"
+          additional_params: "--async --scan-types sast -s https://github.com/luigi-project/luigi.git"
           

--- a/.github/workflows/setupScripts.yml
+++ b/.github/workflows/setupScripts.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '20.14.0'
       - run: |
-          OUT=$(bash ./test/setuptests.sh @angular/cli 4200 http://localhost:4200/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/angular.sh | tee /dev/fd/2)
+          OUT=$(bash ./test/setuptests.sh @angular/cli 4200 http://localhost:4200/ https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/angular.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 4200" <<< "$OUT")
           echo "$RES"
           if [ $RES == 1 ]; then exit 0; else exit 1; fi
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: '20.14.0'
       - run: |
-          OUT=$(bash ./test/setuptests.sh @vue/cli 4173 http://localhost:4173/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/vue.sh | tee /dev/fd/2)
+          OUT=$(bash ./test/setuptests.sh @vue/cli 4173 http://localhost:4173/ https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/vue.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 4173" <<< "$OUT")
           echo "$RES"
           if [ $RES == 1 ]; then exit 0; else exit 1; fi
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: '20.14.0'
       - run: |
-          OUT=$(bash ./test/setuptests.sh 'react-cli react' 3000 http://localhost:3000/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/react.sh | tee /dev/fd/2)
+          OUT=$(bash ./test/setuptests.sh 'react-cli react' 3000 http://localhost:3000/ https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/react.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 3000" <<< "$OUT")
           echo "$RES"
           if [ $RES == 1 ]; then exit 0; else exit 1; fi
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: '20.14.0'
       - run: |
-          OUT=$(bash ./test/setuptests.sh @ui5/cli 8080 http://localhost:8080/index.html#/home https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/openui5.sh | tee /dev/fd/2)
+          OUT=$(bash ./test/setuptests.sh @ui5/cli 8080 http://localhost:8080/index.html#/home https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/openui5.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 8080" <<< "$OUT")
           echo "$RES"
           if [ $RES == 1 ]; then exit 0; else exit 1; fi
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: '20.14.0'
       - run: |
-          OUT=$(bash ./test/setuptests.sh ' ' 3000 http://localhost:3000/ https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/no-framework.sh | tee /dev/fd/2)
+          OUT=$(bash ./test/setuptests.sh ' ' 3000 http://localhost:3000/ https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/no-framework.sh | tee /dev/fd/2)
           RES=$(grep -c "Stopping webserver on port 3000" <<< "$OUT")
           echo "$RES"
           if [ $RES == 1 ]; then exit 0; else exit 1; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.22.1] (2025-05-23)
 
 #### :bug: Fixed
-* [#4293](https://github.com/SAP/luigi/pull/4293) Fix potential memory leak ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4291](https://github.com/SAP/luigi/pull/4291) Fix runtime error in tab nav ([@robertIsaac](https://github.com/robertIsaac))
+* [#4293](https://github.com/luigi-project/luigi/pull/4293) Fix potential memory leak ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4291](https://github.com/luigi-project/luigi/pull/4291) Fix runtime error in tab nav ([@robertIsaac](https://github.com/robertIsaac))
 
 
 
@@ -39,7 +39,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.22.0] (2025-05-20)
 
 #### :rocket: Added
-* [#4266](https://github.com/SAP/luigi/pull/4266) Preserve non client viewgroup iframes ([@walmazacn](https://github.com/walmazacn))
+* [#4266](https://github.com/luigi-project/luigi/pull/4266) Preserve non client viewgroup iframes ([@walmazacn](https://github.com/walmazacn))
 
 
 
@@ -47,7 +47,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.21.3] (2025-04-23)
 
 #### :bug: Fixed
-* [#4229](https://github.com/SAP/luigi/pull/4229) using correct userSettingGroupKey ([@hardl](https://github.com/hardl))
+* [#4229](https://github.com/luigi-project/luigi/pull/4229) using correct userSettingGroupKey ([@hardl](https://github.com/hardl))
 
 
 
@@ -55,7 +55,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.21.2] (2025-03-21)
 
 #### :bug: Fixed
-* [#4194](https://github.com/SAP/luigi/pull/4194) leftnav-btp: fix observer issue ([@hardl](https://github.com/hardl))
+* [#4194](https://github.com/luigi-project/luigi/pull/4194) leftnav-btp: fix observer issue ([@hardl](https://github.com/hardl))
 
 
 
@@ -64,7 +64,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.21.1] (2025-03-04)
 
 #### :bug: Fixed
-* [#4173](https://github.com/SAP/luigi/pull/4173) Bug fix: User menu stays open when not clicking on action items. ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4173](https://github.com/luigi-project/luigi/pull/4173) Bug fix: User menu stays open when not clicking on action items. ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -74,10 +74,10 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.21.0] (2025-02-27)
 
 #### :rocket: Added
-* [#4130](https://github.com/SAP/luigi/pull/4130) Web component based micro frontends in user settings ([@walmazacn](https://github.com/walmazacn))
+* [#4130](https://github.com/luigi-project/luigi/pull/4130) Web component based micro frontends in user settings ([@walmazacn](https://github.com/walmazacn))
 
 #### :bug: Fixed
-* [#4163](https://github.com/SAP/luigi/pull/4163) Fix user menu popover initials bgColor ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4163](https://github.com/luigi-project/luigi/pull/4163) Fix user menu popover initials bgColor ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -87,13 +87,13 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.20.0] (2025-02-18)
 
 #### :rocket: Added
-* [#4144](https://github.com/SAP/luigi/pull/4144) Angular 19 support for client-support-angular library ([@walmazacn](https://github.com/walmazacn))
-* [#4137](https://github.com/SAP/luigi/pull/4137) Appswitcher enhancements ([@hardl](https://github.com/hardl))
+* [#4144](https://github.com/luigi-project/luigi/pull/4144) Angular 19 support for client-support-angular library ([@walmazacn](https://github.com/walmazacn))
+* [#4137](https://github.com/luigi-project/luigi/pull/4137) Appswitcher enhancements ([@hardl](https://github.com/hardl))
 
 #### :bug: Fixed
-* [#4149](https://github.com/SAP/luigi/pull/4149) Filter out empty nav groups ([@hardl](https://github.com/hardl))
-* [#4148](https://github.com/SAP/luigi/pull/4148) Fix: Wrong backgroundColor for profile initials ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4140](https://github.com/SAP/luigi/pull/4140) Accessibility tab order ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4149](https://github.com/luigi-project/luigi/pull/4149) Filter out empty nav groups ([@hardl](https://github.com/hardl))
+* [#4148](https://github.com/luigi-project/luigi/pull/4148) Fix: Wrong backgroundColor for profile initials ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4140](https://github.com/luigi-project/luigi/pull/4140) Accessibility tab order ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -101,15 +101,15 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.19.2] (2025-01-16)
 
 #### :bug: Fixed
-* [#4114](https://github.com/SAP/luigi/pull/4114) switch visibility of usersettings entry after prep of all data ([@hardl](https://github.com/hardl))
+* [#4114](https://github.com/luigi-project/luigi/pull/4114) switch visibility of usersettings entry after prep of all data ([@hardl](https://github.com/hardl))
 
 
 
 ## [v2.19.1] (2025-01-16)
 
 #### :bug: Fixed
-* [#4110](https://github.com/SAP/luigi/pull/4110) Fix: usersettings profile entry when set in afterInit ([@hardl](https://github.com/hardl))
-* [#4102](https://github.com/SAP/luigi/pull/4102) Fix: iconClassAttribute for sap-icons ([@hardl](https://github.com/hardl))
+* [#4110](https://github.com/luigi-project/luigi/pull/4110) Fix: usersettings profile entry when set in afterInit ([@hardl](https://github.com/hardl))
+* [#4102](https://github.com/luigi-project/luigi/pull/4102) Fix: iconClassAttribute for sap-icons ([@hardl](https://github.com/hardl))
 
 
 
@@ -117,8 +117,8 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.19.0] (2024-12-23)
 
 #### :rocket: Added
-* [#4078](https://github.com/SAP/luigi/pull/4078) Mitigation of potential backwards compatibility issue ([@hardl](https://github.com/hardl))
-* [#4077](https://github.com/SAP/luigi/pull/4077) getCurrentRoute in web component client api ([@hardl](https://github.com/hardl))
+* [#4078](https://github.com/luigi-project/luigi/pull/4078) Mitigation of potential backwards compatibility issue ([@hardl](https://github.com/hardl))
+* [#4077](https://github.com/luigi-project/luigi/pull/4077) getCurrentRoute in web component client api ([@hardl](https://github.com/hardl))
 
 
 
@@ -127,16 +127,16 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.18.3] (2024-12-17)
 
 #### :bug: Fixed
-* [#4071](https://github.com/SAP/luigi/pull/4071) Fixes input focus in search field ([@walmazacn](https://github.com/walmazacn))
+* [#4071](https://github.com/luigi-project/luigi/pull/4071) Fixes input focus in search field ([@walmazacn](https://github.com/walmazacn))
 
 
 
 ## [v2.18.2] (2024-12-16)
 
 #### :bug: Fixed
-* [#4068](https://github.com/SAP/luigi/pull/4068) Fixes 'setAttribute' issue in Luigi Client ([@walmazacn](https://github.com/walmazacn))
-* [#4065](https://github.com/SAP/luigi/pull/4065) BtpLayout: Backdrop fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4058](https://github.com/SAP/luigi/pull/4058) Wrong order of productswitcher item ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4068](https://github.com/luigi-project/luigi/pull/4068) Fixes 'setAttribute' issue in Luigi Client ([@walmazacn](https://github.com/walmazacn))
+* [#4065](https://github.com/luigi-project/luigi/pull/4065) BtpLayout: Backdrop fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4058](https://github.com/luigi-project/luigi/pull/4058) Wrong order of productswitcher item ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -146,8 +146,8 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.18.1] (2024-11-29)
 
 #### :bug: Fixed
-* [#4028](https://github.com/SAP/luigi/pull/4028) Auth expiration check reset ([@hardl](https://github.com/hardl))
-* [#4024](https://github.com/SAP/luigi/pull/4024) Fixes accessibility issue in navigation ([@walmazacn](https://github.com/walmazacn))
+* [#4028](https://github.com/luigi-project/luigi/pull/4028) Auth expiration check reset ([@hardl](https://github.com/hardl))
+* [#4024](https://github.com/luigi-project/luigi/pull/4024) Fixes accessibility issue in navigation ([@walmazacn](https://github.com/walmazacn))
 
 
 
@@ -156,8 +156,8 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.18.0] (2024-11-05)
 
 #### :rocket: Added
-* [#4008](https://github.com/SAP/luigi/pull/4008) Adds document attribute for disable tcpcheck ([@walmazacn](https://github.com/walmazacn))
-* [#3983](https://github.com/SAP/luigi/pull/3983) Disable tpc via client ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4008](https://github.com/luigi-project/luigi/pull/4008) Adds document attribute for disable tcpcheck ([@walmazacn](https://github.com/walmazacn))
+* [#3983](https://github.com/luigi-project/luigi/pull/3983) Disable tpc via client ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -166,12 +166,12 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.17.0] (2024-10-02)
 
 #### :rocket: Added
-* [#3946](https://github.com/SAP/luigi/pull/3946) Adds option to disable luigiCookie ([@walmazacn](https://github.com/walmazacn))
-* [#3922](https://github.com/SAP/luigi/pull/3922) Adds node property for hiding global search ([@walmazacn](https://github.com/walmazacn))
+* [#3946](https://github.com/luigi-project/luigi/pull/3946) Adds option to disable luigiCookie ([@walmazacn](https://github.com/walmazacn))
+* [#3922](https://github.com/luigi-project/luigi/pull/3922) Adds node property for hiding global search ([@walmazacn](https://github.com/walmazacn))
 
 #### :bug: Fixed
-* [#3968](https://github.com/SAP/luigi/pull/3968) Fix fdToolLayout background-color ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3964](https://github.com/SAP/luigi/pull/3964) Clean Luigi store ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3968](https://github.com/luigi-project/luigi/pull/3968) Fix fdToolLayout background-color ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3964](https://github.com/luigi-project/luigi/pull/3964) Clean Luigi store ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -181,11 +181,11 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.16.0] (2024-09-27)
 
 #### :rocket: Added
-* [#3938](https://github.com/SAP/luigi/pull/3938) LeftNav in btpLayout: make 'expanded' the default state for nav item groups ([@amilewskaa](https://github.com/amilewskaa))
-* [#3915](https://github.com/SAP/luigi/pull/3915) Adds optional renderer for navHeader ([@walmazacn](https://github.com/walmazacn))
+* [#3938](https://github.com/luigi-project/luigi/pull/3938) LeftNav in btpLayout: make 'expanded' the default state for nav item groups ([@amilewskaa](https://github.com/amilewskaa))
+* [#3915](https://github.com/luigi-project/luigi/pull/3915) Adds optional renderer for navHeader ([@walmazacn](https://github.com/walmazacn))
 
 #### :bug: Fixed
-* [#3902](https://github.com/SAP/luigi/pull/3902) Fixes wrong drawer position ([@walmazacn](https://github.com/walmazacn))
+* [#3902](https://github.com/luigi-project/luigi/pull/3902) Fixes wrong drawer position ([@walmazacn](https://github.com/walmazacn))
 
 
 
@@ -193,7 +193,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.15.0] (2024-08-28)
 
 #### :rocket: Added
-* [#3870](https://github.com/SAP/luigi/pull/3870) Angular 18 support for client-support-angular library ([@walmazacn](https://github.com/walmazacn))
+* [#3870](https://github.com/luigi-project/luigi/pull/3870) Angular 18 support for client-support-angular library ([@walmazacn](https://github.com/walmazacn))
 
 
 
@@ -202,7 +202,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.14.3] (2024-08-22)
 
 #### :bug: Fixed
-* [#3841](https://github.com/SAP/luigi/pull/3841) Fix css issues for btptool layout ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3841](https://github.com/luigi-project/luigi/pull/3841) Fix css issues for btptool layout ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -211,7 +211,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.14.2] (2024-08-01)
 
 #### :bug: Fixed
-* [#3839](https://github.com/SAP/luigi/pull/3839) fix wrong argument for onkeyup ([@hardl](https://github.com/hardl))
+* [#3839](https://github.com/luigi-project/luigi/pull/3839) fix wrong argument for onkeyup ([@hardl](https://github.com/hardl))
 
 
 
@@ -220,7 +220,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.14.1] (2024-07-11)
 
 #### :bug: Fixed
-* [#3812](https://github.com/SAP/luigi/pull/3812) keepPrevious in client ts declaration ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3812](https://github.com/luigi-project/luigi/pull/3812) keepPrevious in client ts declaration ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -230,13 +230,13 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.14.0] (2024-07-03)
 
 #### :rocket: Added
-* [#3787](https://github.com/SAP/luigi/pull/3787) Add support for Nightwatch, WebdriverIO and Puppeteer for testing-utilities ([@walmazacn](https://github.com/walmazacn))
-* [#3780](https://github.com/SAP/luigi/pull/3780) Get current route ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3774](https://github.com/SAP/luigi/pull/3774) Add getCurrentTheme wc clientAPI ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3748](https://github.com/SAP/luigi/pull/3748) Fiddle theming example ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3787](https://github.com/luigi-project/luigi/pull/3787) Add support for Nightwatch, WebdriverIO and Puppeteer for testing-utilities ([@walmazacn](https://github.com/walmazacn))
+* [#3780](https://github.com/luigi-project/luigi/pull/3780) Get current route ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3774](https://github.com/luigi-project/luigi/pull/3774) Add getCurrentTheme wc clientAPI ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3748](https://github.com/luigi-project/luigi/pull/3748) Fiddle theming example ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#3727](https://github.com/SAP/luigi/pull/3727) Fix top nav children not rendered ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3727](https://github.com/luigi-project/luigi/pull/3727) Fix top nav children not rendered ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -244,12 +244,12 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.13.0] (2024-05-23)
 
 #### :rocket: Added
-* [#3719](https://github.com/SAP/luigi/pull/3719) A11y for left nav if btp layout is enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3719](https://github.com/luigi-project/luigi/pull/3719) A11y for left nav if btp layout is enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#3741](https://github.com/SAP/luigi/pull/3741) Fix left nav cat focus outline in condensed mode ([@hardl](https://github.com/hardl))
-* [#3733](https://github.com/SAP/luigi/pull/3733) Fix compound double rendering ([@hardl](https://github.com/hardl))
-* [#3722](https://github.com/SAP/luigi/pull/3722) Add webpack ignore comment to dynamic import in bundle ([@hardl](https://github.com/hardl))
+* [#3741](https://github.com/luigi-project/luigi/pull/3741) Fix left nav cat focus outline in condensed mode ([@hardl](https://github.com/hardl))
+* [#3733](https://github.com/luigi-project/luigi/pull/3733) Fix compound double rendering ([@hardl](https://github.com/hardl))
+* [#3722](https://github.com/luigi-project/luigi/pull/3722) Add webpack ignore comment to dynamic import in bundle ([@hardl](https://github.com/hardl))
 
 
 
@@ -260,10 +260,10 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.12.0] (2024-05-03)
 
 #### :rocket: Added
-* [#3709](https://github.com/SAP/luigi/pull/3709) Ignore page not found error handling by Luigi ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3693](https://github.com/SAP/luigi/pull/3693) Update context via core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3711](https://github.com/SAP/luigi/pull/3711) Change Luigi core version on the fly in Luigi fiddle ([@hardl](https://github.com/hardl))
-* [#3712](https://github.com/SAP/luigi/pull/3712) Remove favicon console warning ([@Jotrorox](https://github.com/Jotrorox))
+* [#3709](https://github.com/luigi-project/luigi/pull/3709) Ignore page not found error handling by Luigi ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3693](https://github.com/luigi-project/luigi/pull/3693) Update context via core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3711](https://github.com/luigi-project/luigi/pull/3711) Change Luigi core version on the fly in Luigi fiddle ([@hardl](https://github.com/hardl))
+* [#3712](https://github.com/luigi-project/luigi/pull/3712) Remove favicon console warning ([@Jotrorox](https://github.com/Jotrorox))
 
 
 
@@ -272,10 +272,10 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.11.0] (2024-04-19)
 
 #### :rocket: Added
-* [#3664](https://github.com/SAP/luigi/pull/3664) Add TabNav navigate on click ([@camelCaseChris](https://github.com/camelCaseChris))
+* [#3664](https://github.com/luigi-project/luigi/pull/3664) Add TabNav navigate on click ([@camelCaseChris](https://github.com/camelCaseChris))
 
 #### :bug: Fixed
-* [#3696](https://github.com/SAP/luigi/pull/3696) Fix dependency issue in client-support-angular ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3696](https://github.com/luigi-project/luigi/pull/3696) Fix dependency issue in client-support-angular ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -283,16 +283,16 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.10.0] (2024-04-09)
 
 #### :rocket: Added
-* [#3672](https://github.com/SAP/luigi/pull/3672) Add on close promise to Luigi Client openAsModal  ([@hardl](https://github.com/hardl))
-* [#3654](https://github.com/SAP/luigi/pull/3654) Cypress support for testing utilities ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3672](https://github.com/luigi-project/luigi/pull/3672) Add on close promise to Luigi Client openAsModal  ([@hardl](https://github.com/hardl))
+* [#3654](https://github.com/luigi-project/luigi/pull/3654) Cypress support for testing utilities ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 #### :bug: Fixed
-* [#3680](https://github.com/SAP/luigi/pull/3680) Fix global nav focus issue ([@hardl](https://github.com/hardl))
-* [#3679](https://github.com/SAP/luigi/pull/3679) Fix loading indicator not going away when fast clicking multiple times to a nav node  ([@hardl](https://github.com/hardl))
-* [#3662](https://github.com/SAP/luigi/pull/3662) Fix runtime error ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3646](https://github.com/SAP/luigi/pull/3646) Fix dynamic params for angular routing([@camelCaseChris](https://github.com/camelCaseChris))
-* [#3652](https://github.com/SAP/luigi/pull/3652) Fix return type of compound container init ([@hardl](https://github.com/hardl))
+* [#3680](https://github.com/luigi-project/luigi/pull/3680) Fix global nav focus issue ([@hardl](https://github.com/hardl))
+* [#3679](https://github.com/luigi-project/luigi/pull/3679) Fix loading indicator not going away when fast clicking multiple times to a nav node  ([@hardl](https://github.com/hardl))
+* [#3662](https://github.com/luigi-project/luigi/pull/3662) Fix runtime error ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3646](https://github.com/luigi-project/luigi/pull/3646) Fix dynamic params for angular routing([@camelCaseChris](https://github.com/camelCaseChris))
+* [#3652](https://github.com/luigi-project/luigi/pull/3652) Fix return type of compound container init ([@hardl](https://github.com/hardl))
 
 
 
@@ -300,13 +300,13 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.9.0] (2024-02-13)
 
 #### :rocket: Added
-* [#3486](https://github.com/SAP/luigi/pull/3486) Btp layout ([@hardl](https://github.com/hardl))
-* [#3638](https://github.com/SAP/luigi/pull/3638) Fix: use SameSite=None and Secure attributes for cookie deletions ([@vladm9800](https://github.com/vladm9800))
-* [#3635](https://github.com/SAP/luigi/pull/3635) Add datatest-id to tab nav ([@ndricimrr](https://github.com/ndricimrr))
-* [#3494](https://github.com/SAP/luigi/pull/3494) Set view group data for wc api ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3486](https://github.com/luigi-project/luigi/pull/3486) Btp layout ([@hardl](https://github.com/hardl))
+* [#3638](https://github.com/luigi-project/luigi/pull/3638) Fix: use SameSite=None and Secure attributes for cookie deletions ([@vladm9800](https://github.com/vladm9800))
+* [#3635](https://github.com/luigi-project/luigi/pull/3635) Add datatest-id to tab nav ([@ndricimrr](https://github.com/ndricimrr))
+* [#3494](https://github.com/luigi-project/luigi/pull/3494) Set view group data for wc api ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#3623](https://github.com/SAP/luigi/pull/3623) Refactor testing-utilities and angular v17 support in client-support-angular library ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3623](https://github.com/luigi-project/luigi/pull/3623) Refactor testing-utilities and angular v17 support in client-support-angular library ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -314,18 +314,18 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.8.0] (2024-01-23)
 
 #### :rocket: Added
-* [#3590](https://github.com/SAP/luigi/pull/3590) Lazy loading option for compound web component mode ([@camelCaseChris](https://github.com/camelCaseChris))
+* [#3590](https://github.com/luigi-project/luigi/pull/3590) Lazy loading option for compound web component mode ([@camelCaseChris](https://github.com/camelCaseChris))
 
 #### :bug: Fixed
-* [#3572](https://github.com/SAP/luigi/pull/3572) Calc max-height for tabNav dropdown ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3564](https://github.com/SAP/luigi/pull/3564) Fix resizing when drawer opens/closes ([@camelCaseChris](https://github.com/camelCaseChris))
+* [#3572](https://github.com/luigi-project/luigi/pull/3572) Calc max-height for tabNav dropdown ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3564](https://github.com/luigi-project/luigi/pull/3564) Fix resizing when drawer opens/closes ([@camelCaseChris](https://github.com/camelCaseChris))
 
 
 
 ## [v2.7.5] (2023-12-06)
 
 #### :bug: Fixed
-* [#3544](https://github.com/SAP/luigi/pull/3544) Fix addNavHrefs for ContextSwitcher and TopNavDropDown ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3544](https://github.com/luigi-project/luigi/pull/3544) Fix addNavHrefs for ContextSwitcher and TopNavDropDown ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -333,9 +333,9 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.7.4] (2023-12-04)
 
 #### :bug: Fixed
-* [#3554](https://github.com/SAP/luigi/pull/3554) Update modal settings after openNodeInModal ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3553](https://github.com/SAP/luigi/pull/3553) Refresh modal width/height in DOM on modal settings update ([@hardl](https://github.com/hardl))
-* [#3552](https://github.com/SAP/luigi/pull/3552) Fix potential race condition in init phase of compound mfe ([@hardl](https://github.com/hardl))
+* [#3554](https://github.com/luigi-project/luigi/pull/3554) Update modal settings after openNodeInModal ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3553](https://github.com/luigi-project/luigi/pull/3553) Refresh modal width/height in DOM on modal settings update ([@hardl](https://github.com/hardl))
+* [#3552](https://github.com/luigi-project/luigi/pull/3552) Fix potential race condition in init phase of compound mfe ([@hardl](https://github.com/hardl))
 
 
 
@@ -345,14 +345,14 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.7.3] (2023-11-30)
 
 #### :bug: Fixed
-* [#3539](https://github.com/SAP/luigi/pull/3539) Prevent multiple eventListener when creating modals ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3539](https://github.com/luigi-project/luigi/pull/3539) Prevent multiple eventListener when creating modals ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
 ## [v2.7.2] (2023-11-14)
 
 #### :bug: Fixed
-* [#3524](https://github.com/SAP/luigi/pull/3524) Update width and height property on updateModalSettings ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3524](https://github.com/luigi-project/luigi/pull/3524) Update width and height property on updateModalSettings ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -360,7 +360,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.7.1] (2023-10-27)
 
 #### :bug: Fixed
-* [#3487](https://github.com/SAP/luigi/pull/3487) Self registered compound node ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3487](https://github.com/luigi-project/luigi/pull/3487) Self registered compound node ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -369,15 +369,15 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.7.0] (2023-10-18)
 
 #### :rocket: Added
-* [#3471](https://github.com/SAP/luigi/pull/3471) Add webcomponentCreationInterceptor ([@hardl](https://github.com/hardl))
-* [#3470](https://github.com/SAP/luigi/pull/3470) Disable topnav option ([@hardl](https://github.com/hardl))
-* [#3458](https://github.com/SAP/luigi/pull/3458) Add getAnchor for wc ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3390](https://github.com/SAP/luigi/pull/3390) Add getPathParams, getCoreSearchParams, getClientPermissions ([@ndricimrr](https://github.com/ndricimrr))
+* [#3471](https://github.com/luigi-project/luigi/pull/3471) Add webcomponentCreationInterceptor ([@hardl](https://github.com/hardl))
+* [#3470](https://github.com/luigi-project/luigi/pull/3470) Disable topnav option ([@hardl](https://github.com/hardl))
+* [#3458](https://github.com/luigi-project/luigi/pull/3458) Add getAnchor for wc ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3390](https://github.com/luigi-project/luigi/pull/3390) Add getPathParams, getCoreSearchParams, getClientPermissions ([@ndricimrr](https://github.com/ndricimrr))
 
 #### :bug: Fixed
-* [#3464](https://github.com/SAP/luigi/pull/3464) A11y improvements in user settings dialog ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3460](https://github.com/SAP/luigi/pull/3460) Condensed sidenav rendering issue on ios safari ([@hardl](https://github.com/hardl))
-* [#3457](https://github.com/SAP/luigi/pull/3457) onNodeActivation async ([@hardl](https://github.com/hardl))
+* [#3464](https://github.com/luigi-project/luigi/pull/3464) A11y improvements in user settings dialog ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3460](https://github.com/luigi-project/luigi/pull/3460) Condensed sidenav rendering issue on ios safari ([@hardl](https://github.com/hardl))
+* [#3457](https://github.com/luigi-project/luigi/pull/3457) onNodeActivation async ([@hardl](https://github.com/hardl))
 
 
 
@@ -385,7 +385,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.6.3] (2023-10-05)
 
 #### :rocket: Added
-* [#3448](https://github.com/SAP/luigi/pull/3448) Update peer dependencies to angular v16 for client-support-angular library ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3448](https://github.com/luigi-project/luigi/pull/3448) Update peer dependencies to angular v16 for client-support-angular library ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -395,7 +395,7 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.6.2] (2023-09-26)
 
 #### :bug: Fixed
-* [#3450](https://github.com/SAP/luigi/pull/3450) detect configChangedRequest only on config changed ([@hardl](https://github.com/hardl))
+* [#3450](https://github.com/luigi-project/luigi/pull/3450) detect configChangedRequest only on config changed ([@hardl](https://github.com/hardl))
 
 
 
@@ -403,8 +403,8 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.6.1] (2023-09-22)
 
 #### :bug: Fixed
-* [#3444](https://github.com/SAP/luigi/pull/3444) Fix path in updateModalSettings ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3443](https://github.com/SAP/luigi/pull/3443) Fix runtime error for wc ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3444](https://github.com/luigi-project/luigi/pull/3444) Fix path in updateModalSettings ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3443](https://github.com/luigi-project/luigi/pull/3443) Fix runtime error for wc ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -414,10 +414,10 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.6.0] (2023-09-20)
 
 #### :rocket: Added
-* [#3414](https://github.com/SAP/luigi/pull/3414) Add getUserSettings for webcomponents ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3414](https://github.com/luigi-project/luigi/pull/3414) Add getUserSettings for webcomponents ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#3438](https://github.com/SAP/luigi/pull/3438) Fix wrong context in leftnav after update ([@hardl](https://github.com/hardl))
+* [#3438](https://github.com/luigi-project/luigi/pull/3438) Fix wrong context in leftnav after update ([@hardl](https://github.com/hardl))
 
 
 
@@ -427,19 +427,19 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.5.1] (2023-09-05)
 
 #### :bug: Fixed
-* [#3429](https://github.com/SAP/luigi/pull/3429) Fix getContextAsync in client lib for angular ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3429](https://github.com/luigi-project/luigi/pull/3429) Fix getContextAsync in client lib for angular ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
 ## [v2.5.0] (2023-08-31)
 
 #### :rocket: Added
-* [#3405](https://github.com/SAP/luigi/pull/3405) Return empty object for getContext ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3416](https://github.com/SAP/luigi/pull/3416) Global context ([@hardl](https://github.com/hardl))
+* [#3405](https://github.com/luigi-project/luigi/pull/3405) Return empty object for getContext ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3416](https://github.com/luigi-project/luigi/pull/3416) Global context ([@hardl](https://github.com/hardl))
 
 #### :bug: Fixed
-* [#3409](https://github.com/SAP/luigi/pull/3409) Statusbadge for horizontal nav ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3406](https://github.com/SAP/luigi/pull/3406) Fix go back context multiple modals ([@ndricimrr](https://github.com/ndricimrr))
+* [#3409](https://github.com/luigi-project/luigi/pull/3409) Statusbadge for horizontal nav ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3406](https://github.com/luigi-project/luigi/pull/3406) Fix go back context multiple modals ([@ndricimrr](https://github.com/ndricimrr))
 
 
 
@@ -447,11 +447,11 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.4.0] (2023-08-23)
 
 #### :rocket: Added
-* [#3389](https://github.com/SAP/luigi/pull/3389) addNodeParams, getNodeParams and setAnchor for wc luigiClient ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3404](https://github.com/SAP/luigi/pull/3404) Remove onunload listener ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3395](https://github.com/SAP/luigi/pull/3395) Added modalSettings.keepPrevious ([@itsajay1029](https://github.com/itsajay1029))
-* [#3394](https://github.com/SAP/luigi/pull/3394) Add data-testid attr to the close button for modal ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3352](https://github.com/SAP/luigi/pull/3352) onLoad functionality for wc mfe ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3389](https://github.com/luigi-project/luigi/pull/3389) addNodeParams, getNodeParams and setAnchor for wc luigiClient ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3404](https://github.com/luigi-project/luigi/pull/3404) Remove onunload listener ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3395](https://github.com/luigi-project/luigi/pull/3395) Added modalSettings.keepPrevious ([@itsajay1029](https://github.com/itsajay1029))
+* [#3394](https://github.com/luigi-project/luigi/pull/3394) Add data-testid attr to the close button for modal ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3352](https://github.com/luigi-project/luigi/pull/3352) onLoad functionality for wc mfe ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -460,20 +460,20 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.3.0] (2023-07-28)
 
 #### :rocket: Added
-* [#3339](https://github.com/SAP/luigi/pull/3339) Write updated modal settings to url ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3326](https://github.com/SAP/luigi/pull/3326) Expand category by navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3234](https://github.com/SAP/luigi/pull/3234) Transfer theme vars ([@hardl](https://github.com/hardl))
-* [#3285](https://github.com/SAP/luigi/pull/3285) Semicollapsible with button ([@hardl](https://github.com/hardl))
-* [#3294](https://github.com/SAP/luigi/pull/3294) Removed internet explorer logic ([@somabagyinszky7](https://github.com/somabagyinszky7))
+* [#3339](https://github.com/luigi-project/luigi/pull/3339) Write updated modal settings to url ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3326](https://github.com/luigi-project/luigi/pull/3326) Expand category by navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3234](https://github.com/luigi-project/luigi/pull/3234) Transfer theme vars ([@hardl](https://github.com/hardl))
+* [#3285](https://github.com/luigi-project/luigi/pull/3285) Semicollapsible with button ([@hardl](https://github.com/hardl))
+* [#3294](https://github.com/luigi-project/luigi/pull/3294) Removed internet explorer logic ([@somabagyinszky7](https://github.com/somabagyinszky7))
 
 #### :bug: Fixed
-* [#3366](https://github.com/SAP/luigi/pull/3366) Fix incomplete context for tabheader mfe ([@hardl](https://github.com/hardl))
-* [#3358](https://github.com/SAP/luigi/pull/3358) Remove wc node when navigate away ([@hardl](https://github.com/hardl))
-* [#3357](https://github.com/SAP/luigi/pull/3357) Tabnav: no context passed to accessibilityResolver ([@hardl](https://github.com/hardl))
-* [#3340](https://github.com/SAP/luigi/pull/3340) Bug-fix: close modal loadingIndicator enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3333](https://github.com/SAP/luigi/pull/3333) Bug-fix: No rendering of categories without children ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3301](https://github.com/SAP/luigi/pull/3301) Added helper method for calculating shellbar height ([@somabagyinszky7](https://github.com/somabagyinszky7))
-* [#3302](https://github.com/SAP/luigi/pull/3302) Changed configChanged scope for vgdata ([@hardl](https://github.com/hardl))
+* [#3366](https://github.com/luigi-project/luigi/pull/3366) Fix incomplete context for tabheader mfe ([@hardl](https://github.com/hardl))
+* [#3358](https://github.com/luigi-project/luigi/pull/3358) Remove wc node when navigate away ([@hardl](https://github.com/hardl))
+* [#3357](https://github.com/luigi-project/luigi/pull/3357) Tabnav: no context passed to accessibilityResolver ([@hardl](https://github.com/hardl))
+* [#3340](https://github.com/luigi-project/luigi/pull/3340) Bug-fix: close modal loadingIndicator enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3333](https://github.com/luigi-project/luigi/pull/3333) Bug-fix: No rendering of categories without children ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3301](https://github.com/luigi-project/luigi/pull/3301) Added helper method for calculating shellbar height ([@somabagyinszky7](https://github.com/somabagyinszky7))
+* [#3302](https://github.com/luigi-project/luigi/pull/3302) Changed configChanged scope for vgdata ([@hardl](https://github.com/hardl))
 
 
 
@@ -481,10 +481,10 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.2.1] (2023-05-26)
 
 #### :bug: Fixed
-* [#3296](https://github.com/SAP/luigi/pull/3296) Fix tabnav header flickering issue ([@hardl](https://github.com/hardl))
-* [#3297](https://github.com/SAP/luigi/pull/3297) Fix WC Compound Rerendering issue ([@hardl](https://github.com/hardl))
-* [#3283](https://github.com/SAP/luigi/pull/3283) CSP improvements ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3276](https://github.com/SAP/luigi/pull/3276) Fix showModalPathInUrl is undefined ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3296](https://github.com/luigi-project/luigi/pull/3296) Fix tabnav header flickering issue ([@hardl](https://github.com/hardl))
+* [#3297](https://github.com/luigi-project/luigi/pull/3297) Fix WC Compound Rerendering issue ([@hardl](https://github.com/hardl))
+* [#3283](https://github.com/luigi-project/luigi/pull/3283) CSP improvements ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3276](https://github.com/luigi-project/luigi/pull/3276) Fix showModalPathInUrl is undefined ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -492,15 +492,15 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.2.0] (2023-05-02)
 
 #### :rocket: Added
-* [#3243](https://github.com/SAP/luigi/pull/3243) Viewgroup live settings ([@hardl](https://github.com/hardl))
-* [#3253](https://github.com/SAP/luigi/pull/3253) tabnav header micro frontend ([@hardl](https://github.com/hardl))
-* [#3226](https://github.com/SAP/luigi/pull/3226) Prevent rerendering of webcomponent ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3240](https://github.com/SAP/luigi/pull/3240) Remove breadcrumbs from experimental flag([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3243](https://github.com/luigi-project/luigi/pull/3243) Viewgroup live settings ([@hardl](https://github.com/hardl))
+* [#3253](https://github.com/luigi-project/luigi/pull/3253) tabnav header micro frontend ([@hardl](https://github.com/hardl))
+* [#3226](https://github.com/luigi-project/luigi/pull/3226) Prevent rerendering of webcomponent ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3240](https://github.com/luigi-project/luigi/pull/3240) Remove breadcrumbs from experimental flag([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#3241](https://github.com/SAP/luigi/pull/3241) Fix confirmation modal on reject result ([@ndricimrr](https://github.com/ndricimrr))
-* [#3258](https://github.com/SAP/luigi/pull/3258) Fix external link same window ([@hardl](https://github.com/hardl))
-* [#3257](https://github.com/SAP/luigi/pull/3257) Accordion element not showing correctly in breadcrumb docu ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+* [#3241](https://github.com/luigi-project/luigi/pull/3241) Fix confirmation modal on reject result ([@ndricimrr](https://github.com/ndricimrr))
+* [#3258](https://github.com/luigi-project/luigi/pull/3258) Fix external link same window ([@hardl](https://github.com/hardl))
+* [#3257](https://github.com/luigi-project/luigi/pull/3257) Accordion element not showing correctly in breadcrumb docu ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 
 
@@ -508,12 +508,12 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.1.0] (2023-03-30)
 
 #### :rocket: Added
-* [#3236](https://github.com/SAP/luigi/pull/3236) Get dirty status via core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3236](https://github.com/luigi-project/luigi/pull/3236) Get dirty status via core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#3247](https://github.com/SAP/luigi/pull/3247) Fix context switcher loading indicator redundant render ([@ndricimrr](https://github.com/ndricimrr))
-* [#3209](https://github.com/SAP/luigi/pull/3209) pkce fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3182](https://github.com/SAP/luigi/pull/3182) Css-fix: wrong top value for iframeContainer when tabnav enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3247](https://github.com/luigi-project/luigi/pull/3247) Fix context switcher loading indicator redundant render ([@ndricimrr](https://github.com/ndricimrr))
+* [#3209](https://github.com/luigi-project/luigi/pull/3209) pkce fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3182](https://github.com/luigi-project/luigi/pull/3182) Css-fix: wrong top value for iframeContainer when tabnav enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -522,69 +522,69 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v2.0.1] (2023-02-14)
 
 #### :bug: Fixed
-* [#3180](https://github.com/SAP/luigi/pull/3180) fix multi alert promise ([@hardl](https://github.com/hardl))
-* [#3179](https://github.com/SAP/luigi/pull/3179) fix backdrop overlay ([@hardl](https://github.com/hardl))
+* [#3180](https://github.com/luigi-project/luigi/pull/3180) fix multi alert promise ([@hardl](https://github.com/hardl))
+* [#3179](https://github.com/luigi-project/luigi/pull/3179) fix backdrop overlay ([@hardl](https://github.com/hardl))
 
 
 
 ## [v2.0.0] (2023-02-10)
 
 #### :boom: Breaking Change
-* [#3078](https://github.com/SAP/luigi/pull/3078) Update angular support library to angular v14 ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3078](https://github.com/luigi-project/luigi/pull/3078) Update angular support library to angular v14 ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :rocket: Added
-* [#3136](https://github.com/SAP/luigi/pull/3136) Hide tab nav automatically ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3126](https://github.com/SAP/luigi/pull/3126) Update Fundamental styles to v0.26.5 ([@hardl](https://github.com/hardl))
+* [#3136](https://github.com/luigi-project/luigi/pull/3136) Hide tab nav automatically ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3126](https://github.com/luigi-project/luigi/pull/3126) Update Fundamental styles to v0.26.5 ([@hardl](https://github.com/hardl))
 
 #### :bug: Fixed
-* [#3152](https://github.com/SAP/luigi/pull/3152) Css-fix: tabNav + breadcrumb ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3152](https://github.com/luigi-project/luigi/pull/3152) Css-fix: tabNav + breadcrumb ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
 ## [v1.26.0] (2023-01-16)
 
 #### :rocket: Added
-* [#3094](https://github.com/SAP/luigi/pull/3094) Enhance left nav a11y ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3049](https://github.com/SAP/luigi/pull/3049) Add callback to openAsModal for core api ([@hardl](https://github.com/hardl))
-* [#2963](https://github.com/SAP/luigi/pull/2963) LuigiClient type declaration for web components ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2955](https://github.com/SAP/luigi/pull/2955) Allow right alignment of statusBadge ([@hardl](https://github.com/hardl))
-* [#3013](https://github.com/SAP/luigi/pull/3013) Tooltip for categories expand collapse button ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2980](https://github.com/SAP/luigi/pull/2980) Add 'isDrawer' to luigi client api ([@ndricimrr](https://github.com/ndricimrr))
-* [#2941](https://github.com/SAP/luigi/pull/2941) Add external link option for IBN ([@ndricimrr](https://github.com/ndricimrr))
-* [#2932](https://github.com/SAP/luigi/pull/2932) Allow LuigiElement shadow mode configuration ([@ndricimrr](https://github.com/ndricimrr))
-* [#3072](https://github.com/SAP/luigi/pull/3072) History handling for modals ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3094](https://github.com/luigi-project/luigi/pull/3094) Enhance left nav a11y ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3049](https://github.com/luigi-project/luigi/pull/3049) Add callback to openAsModal for core api ([@hardl](https://github.com/hardl))
+* [#2963](https://github.com/luigi-project/luigi/pull/2963) LuigiClient type declaration for web components ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2955](https://github.com/luigi-project/luigi/pull/2955) Allow right alignment of statusBadge ([@hardl](https://github.com/hardl))
+* [#3013](https://github.com/luigi-project/luigi/pull/3013) Tooltip for categories expand collapse button ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2980](https://github.com/luigi-project/luigi/pull/2980) Add 'isDrawer' to luigi client api ([@ndricimrr](https://github.com/ndricimrr))
+* [#2941](https://github.com/luigi-project/luigi/pull/2941) Add external link option for IBN ([@ndricimrr](https://github.com/ndricimrr))
+* [#2932](https://github.com/luigi-project/luigi/pull/2932) Allow LuigiElement shadow mode configuration ([@ndricimrr](https://github.com/ndricimrr))
+* [#3072](https://github.com/luigi-project/luigi/pull/3072) History handling for modals ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#2984](https://github.com/SAP/luigi/pull/2984) Fix unsaved changes modal not closing after browser back  ([@ndricimrr](https://github.com/ndricimrr))
-* [#3039](https://github.com/SAP/luigi/pull/3039) Fix drawer overlap ([@hardl](https://github.com/hardl))
-* [#2953](https://github.com/SAP/luigi/pull/2953) Fix broken link ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-* [#2901](https://github.com/SAP/luigi/pull/2901) Plus sign not decoded correctly when adding and then getting nodeParams ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2949](https://github.com/SAP/luigi/pull/2949) Add missing withOptions function typings ([@ndricimrr](https://github.com/ndricimrr))
+* [#2984](https://github.com/luigi-project/luigi/pull/2984) Fix unsaved changes modal not closing after browser back  ([@ndricimrr](https://github.com/ndricimrr))
+* [#3039](https://github.com/luigi-project/luigi/pull/3039) Fix drawer overlap ([@hardl](https://github.com/hardl))
+* [#2953](https://github.com/luigi-project/luigi/pull/2953) Fix broken link ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+* [#2901](https://github.com/luigi-project/luigi/pull/2901) Plus sign not decoded correctly when adding and then getting nodeParams ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2949](https://github.com/luigi-project/luigi/pull/2949) Add missing withOptions function typings ([@ndricimrr](https://github.com/ndricimrr))
 
 
 
 ## [v1.25.1] (2022-10-04)
 #### :bug: Fixed
-* [#2838](https://github.com/SAP/luigi/pull/2915) Fix client-support-angular deps ([@hardl](https://github.com/hardl))
+* [#2838](https://github.com/luigi-project/luigi/pull/2915) Fix client-support-angular deps ([@hardl](https://github.com/hardl))
 
 
 
 ## [v1.25.0] (2022-09-30)
 
 #### :rocket: Added
-* [#2908](https://github.com/SAP/luigi/pull/2908) Ignore events from inactive iframes ([@hardl](https://github.com/hardl))
-* [#2893](https://github.com/SAP/luigi/pull/2893) Add getActiveFeatureToggles in Luigi WC ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2900](https://github.com/SAP/luigi/pull/2900) CRA Luigi Template ([@ndricimrr](https://github.com/ndricimrr))
-* [#2878](https://github.com/SAP/luigi/pull/2878) Implement tests by using luigi mock module ([@viktorsperling](https://github.com/viktorsperling))
-* [#2858](https://github.com/SAP/luigi/pull/2858) Add Viewgroup Background Option ([@ndricimrr](https://github.com/ndricimrr))
-* [#2873](https://github.com/SAP/luigi/pull/2873) Hide top navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2861](https://github.com/SAP/luigi/pull/2861) Introduce js-test-application for e2e tests ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2808](https://github.com/SAP/luigi/pull/2808) Remove javascript void from nav href ([@ndricimrr](https://github.com/ndricimrr))
+* [#2908](https://github.com/luigi-project/luigi/pull/2908) Ignore events from inactive iframes ([@hardl](https://github.com/hardl))
+* [#2893](https://github.com/luigi-project/luigi/pull/2893) Add getActiveFeatureToggles in Luigi WC ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2900](https://github.com/luigi-project/luigi/pull/2900) CRA Luigi Template ([@ndricimrr](https://github.com/ndricimrr))
+* [#2878](https://github.com/luigi-project/luigi/pull/2878) Implement tests by using luigi mock module ([@viktorsperling](https://github.com/viktorsperling))
+* [#2858](https://github.com/luigi-project/luigi/pull/2858) Add Viewgroup Background Option ([@ndricimrr](https://github.com/ndricimrr))
+* [#2873](https://github.com/luigi-project/luigi/pull/2873) Hide top navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2861](https://github.com/luigi-project/luigi/pull/2861) Introduce js-test-application for e2e tests ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2808](https://github.com/luigi-project/luigi/pull/2808) Remove javascript void from nav href ([@ndricimrr](https://github.com/ndricimrr))
 
 #### :bug: Fixed
-* [#2838](https://github.com/SAP/luigi/pull/2838) Fix sessionStorage not working ([@hardl](https://github.com/hardl))
-* [#2850](https://github.com/SAP/luigi/pull/2850) Fix preload url routing ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2827](https://github.com/SAP/luigi/pull/2827) Fix mkdocs.yml file ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+* [#2838](https://github.com/luigi-project/luigi/pull/2838) Fix sessionStorage not working ([@hardl](https://github.com/hardl))
+* [#2850](https://github.com/luigi-project/luigi/pull/2850) Fix preload url routing ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2827](https://github.com/luigi-project/luigi/pull/2827) Fix mkdocs.yml file ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 
 
@@ -592,16 +592,16 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.24.0] (2022-07-15)
 
 #### :rocket: Added
-* [#2803](https://github.com/SAP/luigi/pull/2803) Add decode mfe src url search params option ([@hardl](https://github.com/hardl))
-* [#2674](https://github.com/SAP/luigi/pull/2674) Custom item renderer for app switcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2770](https://github.com/SAP/luigi/pull/2770) Responsive padding for the Shellbar Component ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2765](https://github.com/SAP/luigi/pull/2785) Multiple modal dialogs ([@ndricimrr](https://github.com/ndricimrr))
+* [#2803](https://github.com/luigi-project/luigi/pull/2803) Add decode mfe src url search params option ([@hardl](https://github.com/hardl))
+* [#2674](https://github.com/luigi-project/luigi/pull/2674) Custom item renderer for app switcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2770](https://github.com/luigi-project/luigi/pull/2770) Responsive padding for the Shellbar Component ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2765](https://github.com/luigi-project/luigi/pull/2785) Multiple modal dialogs ([@ndricimrr](https://github.com/ndricimrr))
 
 #### :bug: Fixed
-* [#2807](https://github.com/SAP/luigi/pull/2807) Remove backdrop on node change ([@ndricimrr](https://github.com/ndricimrr))
-* [#2792](https://github.com/SAP/luigi/pull/2792) Fix patchy product switch grid icon ([@hardl](https://github.com/hardl))
-* [#2783](https://github.com/SAP/luigi/pull/2783) Fixed viewgroup inheritance ([@hardl](https://github.com/hardl))
-* [#2765](https://github.com/SAP/luigi/pull/2765) Refactor buildpath for getcurrentpath ([@ndricimrr](https://github.com/ndricimrr))
+* [#2807](https://github.com/luigi-project/luigi/pull/2807) Remove backdrop on node change ([@ndricimrr](https://github.com/ndricimrr))
+* [#2792](https://github.com/luigi-project/luigi/pull/2792) Fix patchy product switch grid icon ([@hardl](https://github.com/hardl))
+* [#2783](https://github.com/luigi-project/luigi/pull/2783) Fixed viewgroup inheritance ([@hardl](https://github.com/hardl))
+* [#2765](https://github.com/luigi-project/luigi/pull/2765) Refactor buildpath for getcurrentpath ([@ndricimrr](https://github.com/ndricimrr))
 
 
 
@@ -611,10 +611,10 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.23.1] (2022-06-20)
 
 #### :rocket: Added
-* [#2748](https://github.com/SAP/luigi/pull/2748) Improve dom selectors in Luigi API ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2748](https://github.com/luigi-project/luigi/pull/2748) Improve dom selectors in Luigi API ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
-* [#2756](https://github.com/SAP/luigi/pull/2756) Fix getCurrentPath collision with buildPath ([@hardl](https://github.com/hardl))
+* [#2756](https://github.com/luigi-project/luigi/pull/2756) Fix getCurrentPath collision with buildPath ([@hardl](https://github.com/hardl))
 
 
 
@@ -623,16 +623,16 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.23.0] (2022-06-17)
 
 #### :rocket: Added
-* [#2752](https://github.com/SAP/luigi/pull/2752) Disable keyboard accessibility for user settings dialog ([@ndricimrr](https://github.com/ndricimrr))
-* [#2739](https://github.com/SAP/luigi/pull/2739) Add getCurrentRoute linkmanager ([@ndricimrr](https://github.com/ndricimrr))
-* [#2691](https://github.com/SAP/luigi/pull/2691) Scalable keyboard accessibility for Dropdown in User Settings Dialog ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2723](https://github.com/SAP/luigi/pull/2723) Update all Core examples with latest versions of Luigi Core/Client and FD Styles ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2752](https://github.com/luigi-project/luigi/pull/2752) Disable keyboard accessibility for user settings dialog ([@ndricimrr](https://github.com/ndricimrr))
+* [#2739](https://github.com/luigi-project/luigi/pull/2739) Add getCurrentRoute linkmanager ([@ndricimrr](https://github.com/ndricimrr))
+* [#2691](https://github.com/luigi-project/luigi/pull/2691) Scalable keyboard accessibility for Dropdown in User Settings Dialog ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2723](https://github.com/luigi-project/luigi/pull/2723) Update all Core examples with latest versions of Luigi Core/Client and FD Styles ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
-* [#2753](https://github.com/SAP/luigi/pull/2753) FIx feature toggles reading phase ([@hardl](https://github.com/hardl))
-* [#2742](https://github.com/SAP/luigi/pull/2742) Fix updateModalPathInternalNavigation not working with options ([@hardl](https://github.com/hardl))
-* [#2745](https://github.com/SAP/luigi/pull/2745) Signout entry misaligned in simple Profile Menu ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2740](https://github.com/SAP/luigi/pull/2740) Fix typo in angular support lib docu ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+* [#2753](https://github.com/luigi-project/luigi/pull/2753) FIx feature toggles reading phase ([@hardl](https://github.com/hardl))
+* [#2742](https://github.com/luigi-project/luigi/pull/2742) Fix updateModalPathInternalNavigation not working with options ([@hardl](https://github.com/hardl))
+* [#2745](https://github.com/luigi-project/luigi/pull/2745) Signout entry misaligned in simple Profile Menu ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2740](https://github.com/luigi-project/luigi/pull/2740) Fix typo in angular support lib docu ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 
 
@@ -641,17 +641,17 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.22.0] (2022-05-19)
 
 #### :rocket: Added
-* [#2704](https://github.com/SAP/luigi/pull/2704) Disable keyboard accessibility outside drawer and modal ([@ndricimrr](https://github.com/ndricimrr))
-* [#2672](https://github.com/SAP/luigi/pull/2672) Disable keyboard accessibility on confirmation modal background elements  ([@ndricimrr](https://github.com/ndricimrr))
-* [#2642](https://github.com/SAP/luigi/pull/2642) Add functionality for allow attribute to be separated by semicolons ([@viktorsperling](https://github.com/viktorsperling))
+* [#2704](https://github.com/luigi-project/luigi/pull/2704) Disable keyboard accessibility outside drawer and modal ([@ndricimrr](https://github.com/ndricimrr))
+* [#2672](https://github.com/luigi-project/luigi/pull/2672) Disable keyboard accessibility on confirmation modal background elements  ([@ndricimrr](https://github.com/ndricimrr))
+* [#2642](https://github.com/luigi-project/luigi/pull/2642) Add functionality for allow attribute to be separated by semicolons ([@viktorsperling](https://github.com/viktorsperling))
 
 #### :bug: Fixed
-* [#2709](https://github.com/SAP/luigi/pull/2709) Fix configChange event firing twice ([@ndricimrr](https://github.com/ndricimrr))
-* [#2692](https://github.com/SAP/luigi/pull/2692) Fix empty nodeParams on browser back navigation ([@ndricimrr](https://github.com/ndricimrr))
-* [#2694](https://github.com/SAP/luigi/pull/2694) Fix bug for nested properties for viewUrl replacement ([@hardl](https://github.com/hardl))
-* [#2686](https://github.com/SAP/luigi/pull/2686) Fix getNodeParams decoding issue ([@ndricimrr](https://github.com/ndricimrr))
-* [#2566](https://github.com/SAP/luigi/pull/2566) Keyboard accessibility for user settings dialog ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2666](https://github.com/SAP/luigi/pull/2666) Error handling on productswitcher columns calculation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2709](https://github.com/luigi-project/luigi/pull/2709) Fix configChange event firing twice ([@ndricimrr](https://github.com/ndricimrr))
+* [#2692](https://github.com/luigi-project/luigi/pull/2692) Fix empty nodeParams on browser back navigation ([@ndricimrr](https://github.com/ndricimrr))
+* [#2694](https://github.com/luigi-project/luigi/pull/2694) Fix bug for nested properties for viewUrl replacement ([@hardl](https://github.com/hardl))
+* [#2686](https://github.com/luigi-project/luigi/pull/2686) Fix getNodeParams decoding issue ([@ndricimrr](https://github.com/ndricimrr))
+* [#2566](https://github.com/luigi-project/luigi/pull/2566) Keyboard accessibility for user settings dialog ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2666](https://github.com/luigi-project/luigi/pull/2666) Error handling on productswitcher columns calculation ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -659,31 +659,31 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.21.0] (2022-04-07)
 
 #### :rocket: Added
-* [#2505](https://github.com/SAP/luigi/pull/2505) withoutSync navigation for modalPathParam ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2584](https://github.com/SAP/luigi/pull/2584) Update Fundamental Styles in Luigi Core to v0.20.0 ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2622](https://github.com/SAP/luigi/pull/2622) Remove experimental flag for webcomponents ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2607](https://github.com/SAP/luigi/pull/2607) Set modal size more precise ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2598](https://github.com/SAP/luigi/pull/2598) keepURL in pagenotfoundhandler ([@hardl](https://github.com/hardl))
-* [#2509](https://github.com/SAP/luigi/pull/2509) Core navigate function returns promise ([@rafalgamon](https://github.com/rafalgamon))
-* [#2488](https://github.com/SAP/luigi/pull/2488) Add function which allows to get the footer container ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2599](https://github.com/SAP/luigi/pull/2599) Url anchor support for micro frontends([@stanleychh](https://github.com/stanleychh))
+* [#2505](https://github.com/luigi-project/luigi/pull/2505) withoutSync navigation for modalPathParam ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2584](https://github.com/luigi-project/luigi/pull/2584) Update Fundamental Styles in Luigi Core to v0.20.0 ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2622](https://github.com/luigi-project/luigi/pull/2622) Remove experimental flag for webcomponents ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2607](https://github.com/luigi-project/luigi/pull/2607) Set modal size more precise ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2598](https://github.com/luigi-project/luigi/pull/2598) keepURL in pagenotfoundhandler ([@hardl](https://github.com/hardl))
+* [#2509](https://github.com/luigi-project/luigi/pull/2509) Core navigate function returns promise ([@rafalgamon](https://github.com/rafalgamon))
+* [#2488](https://github.com/luigi-project/luigi/pull/2488) Add function which allows to get the footer container ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2599](https://github.com/luigi-project/luigi/pull/2599) Url anchor support for micro frontends([@stanleychh](https://github.com/stanleychh))
 
 #### :bug: Fixed
-* [#2629](https://github.com/SAP/luigi/pull/2629) Fix click support for open in new tab function ([@ndricimrr](https://github.com/ndricimrr))
-* [#2626](https://github.com/SAP/luigi/pull/2626) Hide empty categories ([@hardl](https://github.com/hardl))
-* [#2620](https://github.com/SAP/luigi/pull/2620) Fix splitview overlapping issue ([@ndricimrr](https://github.com/ndricimrr))
-* [#2605](https://github.com/SAP/luigi/pull/2605) Fix faulty pathExists race condition ([@ndricimrr](https://github.com/ndricimrr))
-* [#2610](https://github.com/SAP/luigi/pull/2610) Add updateModalSettings typings ([@ndricimrr](https://github.com/ndricimrr))
-* [#2611](https://github.com/SAP/luigi/pull/2611) Prevent double init in web components ([@hardl](https://github.com/hardl))
-* [#2537](https://github.com/SAP/luigi/pull/2537) Context update for user settings microfrontends ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2594](https://github.com/SAP/luigi/pull/2594) Confirmation modal from special iframe mfes ([@hardl](https://github.com/hardl))
-* [#2527](https://github.com/SAP/luigi/pull/2527) Error handling global search centered ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2512](https://github.com/SAP/luigi/pull/2512) Set CSS-variable for badge color ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2492](https://github.com/SAP/luigi/pull/2492) Fix Search params not being deleted ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2498](https://github.com/SAP/luigi/pull/2498) Hide side navigation footer when it is collapsed and has "Fiori3" type ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2490](https://github.com/SAP/luigi/pull/2490) Fix node params not working when hashrouting enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2452](https://github.com/SAP/luigi/pull/2452) Make User Setting dialog to use compact controls and add User Account avatar([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2627](https://github.com/SAP/luigi/pull/2627) Fixed search params encoded twice issue ([@stanleychh](https://github.com/stanleychh))
+* [#2629](https://github.com/luigi-project/luigi/pull/2629) Fix click support for open in new tab function ([@ndricimrr](https://github.com/ndricimrr))
+* [#2626](https://github.com/luigi-project/luigi/pull/2626) Hide empty categories ([@hardl](https://github.com/hardl))
+* [#2620](https://github.com/luigi-project/luigi/pull/2620) Fix splitview overlapping issue ([@ndricimrr](https://github.com/ndricimrr))
+* [#2605](https://github.com/luigi-project/luigi/pull/2605) Fix faulty pathExists race condition ([@ndricimrr](https://github.com/ndricimrr))
+* [#2610](https://github.com/luigi-project/luigi/pull/2610) Add updateModalSettings typings ([@ndricimrr](https://github.com/ndricimrr))
+* [#2611](https://github.com/luigi-project/luigi/pull/2611) Prevent double init in web components ([@hardl](https://github.com/hardl))
+* [#2537](https://github.com/luigi-project/luigi/pull/2537) Context update for user settings microfrontends ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2594](https://github.com/luigi-project/luigi/pull/2594) Confirmation modal from special iframe mfes ([@hardl](https://github.com/hardl))
+* [#2527](https://github.com/luigi-project/luigi/pull/2527) Error handling global search centered ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2512](https://github.com/luigi-project/luigi/pull/2512) Set CSS-variable for badge color ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2492](https://github.com/luigi-project/luigi/pull/2492) Fix Search params not being deleted ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2498](https://github.com/luigi-project/luigi/pull/2498) Hide side navigation footer when it is collapsed and has "Fiori3" type ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2490](https://github.com/luigi-project/luigi/pull/2490) Fix node params not working when hashrouting enabled ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2452](https://github.com/luigi-project/luigi/pull/2452) Make User Setting dialog to use compact controls and add User Account avatar([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2627](https://github.com/luigi-project/luigi/pull/2627) Fixed search params encoded twice issue ([@stanleychh](https://github.com/stanleychh))
 
 
 
@@ -694,90 +694,90 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.20.1] (2022-01-21)
 
 #### :bug: Fixed
-* [#2483](https://github.com/SAP/luigi/pull/2483) Escaping helpers improvement and config fix of e2e app ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2475](https://github.com/SAP/luigi/pull/2475) Fix - getCoreSearchParams should not return undefined ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2424](https://github.com/SAP/luigi/pull/2424) Fixed navigation flyout styles CSS variables ([@rafalgamon](https://github.com/rafalgamon))
-* [#2474](https://github.com/SAP/luigi/pull/2474) Style active node in ShellBar ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2472](https://github.com/SAP/luigi/pull/2472) Node params are not deleted ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2466](https://github.com/SAP/luigi/pull/2466) Proper styling for App Switcher with one entity ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2467](https://github.com/SAP/luigi/pull/2467) Oidc mockserver fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2469](https://github.com/SAP/luigi/pull/2469) Fixed additional sap icon fonts ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2483](https://github.com/luigi-project/luigi/pull/2483) Escaping helpers improvement and config fix of e2e app ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2475](https://github.com/luigi-project/luigi/pull/2475) Fix - getCoreSearchParams should not return undefined ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2424](https://github.com/luigi-project/luigi/pull/2424) Fixed navigation flyout styles CSS variables ([@rafalgamon](https://github.com/rafalgamon))
+* [#2474](https://github.com/luigi-project/luigi/pull/2474) Style active node in ShellBar ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2472](https://github.com/luigi-project/luigi/pull/2472) Node params are not deleted ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2466](https://github.com/luigi-project/luigi/pull/2466) Proper styling for App Switcher with one entity ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2467](https://github.com/luigi-project/luigi/pull/2467) Oidc mockserver fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2469](https://github.com/luigi-project/luigi/pull/2469) Fixed additional sap icon fonts ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 ## [v1.20.0] (2021-12-23)
 
 #### :rocket: Added
-* [#2432](https://github.com/SAP/luigi/pull/2432) Change sap-icon-- to icon function ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2385](https://github.com/SAP/luigi/pull/2385) Searchfield configurable - global searchfield centered ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2370](https://github.com/SAP/luigi/pull/2370) Dynamic pathSegment for breadcrumbs NavHeader ([@hardl](https://github.com/hardl))
-* [#2409](https://github.com/SAP/luigi/pull/2409) Params handling improvements ([@stanleychh](https://github.com/stanleychh))
+* [#2432](https://github.com/luigi-project/luigi/pull/2432) Change sap-icon-- to icon function ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2385](https://github.com/luigi-project/luigi/pull/2385) Searchfield configurable - global searchfield centered ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2370](https://github.com/luigi-project/luigi/pull/2370) Dynamic pathSegment for breadcrumbs NavHeader ([@hardl](https://github.com/hardl))
+* [#2409](https://github.com/luigi-project/luigi/pull/2409) Params handling improvements ([@stanleychh](https://github.com/stanleychh))
 
 #### :bug: Fixed
-* [#2456](https://github.com/SAP/luigi/pull/2456) Disable double scroll when zooming in the browser ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2447](https://github.com/SAP/luigi/pull/2447) Fix category icon not applied if category not on first node ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2437](https://github.com/SAP/luigi/pull/2437) Fixed nodeChangeHook issues ([@hardl](https://github.com/hardl))
-* [#2393](https://github.com/SAP/luigi/pull/2393) Strip query params in linkmanager navigate ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2425](https://github.com/SAP/luigi/pull/2425) Search field clear btn on global search centered ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2403](https://github.com/SAP/luigi/pull/2403) Fix Luigi Context Observable running outside of Angular Zone ([@SomeKay](https://github.com/SomeKay))
+* [#2456](https://github.com/luigi-project/luigi/pull/2456) Disable double scroll when zooming in the browser ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2447](https://github.com/luigi-project/luigi/pull/2447) Fix category icon not applied if category not on first node ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2437](https://github.com/luigi-project/luigi/pull/2437) Fixed nodeChangeHook issues ([@hardl](https://github.com/hardl))
+* [#2393](https://github.com/luigi-project/luigi/pull/2393) Strip query params in linkmanager navigate ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2425](https://github.com/luigi-project/luigi/pull/2425) Search field clear btn on global search centered ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2403](https://github.com/luigi-project/luigi/pull/2403) Fix Luigi Context Observable running outside of Angular Zone ([@SomeKay](https://github.com/SomeKay))
 
 
 
 ## [v1.19.0] (2021-11-26)
 
 #### :rocket: Added
-* [#2383](https://github.com/SAP/luigi/pull/2383) Introduce clearNavigationCache() to clear children and titleResolver cache ([@stanleychh](https://github.com/stanleychh))
-* [#2369](https://github.com/SAP/luigi/pull/2369) Replace CSS static value with SAP Fiori 3 variable in LeftNav ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2352](https://github.com/SAP/luigi/pull/2352) Node category merging improvements ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2383](https://github.com/luigi-project/luigi/pull/2383) Introduce clearNavigationCache() to clear children and titleResolver cache ([@stanleychh](https://github.com/stanleychh))
+* [#2369](https://github.com/luigi-project/luigi/pull/2369) Replace CSS static value with SAP Fiori 3 variable in LeftNav ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2352](https://github.com/luigi-project/luigi/pull/2352) Node category merging improvements ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#2391](https://github.com/SAP/luigi/pull/2391) Style language dropdown under User Settings Dialog ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2375](https://github.com/SAP/luigi/pull/2375) Webcomponent drawer overlap bug ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2289](https://github.com/SAP/luigi/pull/2289) Fixed context update for special iframes ([@rafalgamon](https://github.com/rafalgamon))
-* [#2374](https://github.com/SAP/luigi/pull/2374) Make User Menu type of Fiori3 to use 'Compact' mode instead of 'Cozy' ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2391](https://github.com/luigi-project/luigi/pull/2391) Style language dropdown under User Settings Dialog ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2375](https://github.com/luigi-project/luigi/pull/2375) Webcomponent drawer overlap bug ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2289](https://github.com/luigi-project/luigi/pull/2289) Fixed context update for special iframes ([@rafalgamon](https://github.com/rafalgamon))
+* [#2374](https://github.com/luigi-project/luigi/pull/2374) Make User Menu type of Fiori3 to use 'Compact' mode instead of 'Cozy' ([@UlianaMunich](https://github.com/UlianaMunich))
 
 
 ## [v1.18.1] (2021-11-08)
 
 #### :bug: Fixed
-* [#license udpate](https://github.com/SAP/luigi/commit/a939f5af62f332a0941979d9bd93de93e8f9b776) Added license to client-support-angular library ([@hardl](https://github.com/hardl))
+* [#license udpate](https://github.com/luigi-project/luigi/commit/a939f5af62f332a0941979d9bd93de93e8f9b776) Added license to client-support-angular library ([@hardl](https://github.com/hardl))
 
 ## [v1.18.0] (2021-11-02)
 
 #### :rocket: Added
-* [#2298](https://github.com/SAP/luigi/pull/2298) Check if given path exists for core/client openAsX functions ([@ndricimrr](https://github.com/ndricimrr))
-* [#2336](https://github.com/SAP/luigi/pull/2336) Update Luigi Core/Client in examples Apps ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2280](https://github.com/SAP/luigi/pull/2280) Fixed visibleForFeatureToggles for Compound WebComponent ([@rafalgamon](https://github.com/rafalgamon))
-* [#2304](https://github.com/SAP/luigi/pull/2304) Feature - customAlertHandler ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2242](https://github.com/SAP/luigi/pull/2242) Add tooltipText param to TopNav and LeftNav ([@rafalgamon](https://github.com/rafalgamon))
-* [#2294](https://github.com/SAP/luigi/pull/2294) Fixed resizing main iframe container if a drawer is opened ([@rafalgamon](https://github.com/rafalgamon))
-* [#2322](https://github.com/SAP/luigi/pull/2322) Update modal title and size from micro frontend ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2288](https://github.com/SAP/luigi/pull/2288) Enable core api templating for compound children and external link node ([@stanleychh](https://github.com/stanleychh))
+* [#2298](https://github.com/luigi-project/luigi/pull/2298) Check if given path exists for core/client openAsX functions ([@ndricimrr](https://github.com/ndricimrr))
+* [#2336](https://github.com/luigi-project/luigi/pull/2336) Update Luigi Core/Client in examples Apps ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2280](https://github.com/luigi-project/luigi/pull/2280) Fixed visibleForFeatureToggles for Compound WebComponent ([@rafalgamon](https://github.com/rafalgamon))
+* [#2304](https://github.com/luigi-project/luigi/pull/2304) Feature - customAlertHandler ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2242](https://github.com/luigi-project/luigi/pull/2242) Add tooltipText param to TopNav and LeftNav ([@rafalgamon](https://github.com/rafalgamon))
+* [#2294](https://github.com/luigi-project/luigi/pull/2294) Fixed resizing main iframe container if a drawer is opened ([@rafalgamon](https://github.com/rafalgamon))
+* [#2322](https://github.com/luigi-project/luigi/pull/2322) Update modal title and size from micro frontend ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2288](https://github.com/luigi-project/luigi/pull/2288) Enable core api templating for compound children and external link node ([@stanleychh](https://github.com/stanleychh))
 
 #### :bug: Fixed
-* [#2333](https://github.com/SAP/luigi/pull/2333) Fix changeable settings config properties ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2332](https://github.com/SAP/luigi/pull/2332) Rename aria-label from Avatar to Username ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2350](https://github.com/SAP/luigi/pull/2350) Changeable routing config properties  ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2333](https://github.com/luigi-project/luigi/pull/2333) Fix changeable settings config properties ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2332](https://github.com/luigi-project/luigi/pull/2332) Rename aria-label from Avatar to Username ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2350](https://github.com/luigi-project/luigi/pull/2350) Changeable routing config properties  ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 ## [v1.17.0] (2021-10-12)
 
 #### :rocket: Added
-* [#2286](https://github.com/SAP/luigi/pull/2286) Resolve intent path to actual path ([@ndricimrr](https://github.com/ndricimrr))
-* [#2293](https://github.com/SAP/luigi/pull/2293) Refactor the Language Dropdown under User Settings Dialog ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2219](https://github.com/SAP/luigi/pull/2219) Expose getCurrentLocale in webcomponent luigi client ([@Patil2099](https://github.com/Patil2099))
-* [#2267](https://github.com/SAP/luigi/pull/2267) Expand path exists to intent check ([@ndricimrr](https://github.com/ndricimrr))
-* [#2256](https://github.com/SAP/luigi/pull/2256) Make Profile Dropdown entities accessible via keyboard([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2286](https://github.com/luigi-project/luigi/pull/2286) Resolve intent path to actual path ([@ndricimrr](https://github.com/ndricimrr))
+* [#2293](https://github.com/luigi-project/luigi/pull/2293) Refactor the Language Dropdown under User Settings Dialog ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2219](https://github.com/luigi-project/luigi/pull/2219) Expose getCurrentLocale in webcomponent luigi client ([@Patil2099](https://github.com/Patil2099))
+* [#2267](https://github.com/luigi-project/luigi/pull/2267) Expand path exists to intent check ([@ndricimrr](https://github.com/ndricimrr))
+* [#2256](https://github.com/luigi-project/luigi/pull/2256) Make Profile Dropdown entities accessible via keyboard([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
-* [#2306](https://github.com/SAP/luigi/pull/2306) Fixing cursor for a "Fiori3" Profile Dropdown in Shellbar ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2314](https://github.com/SAP/luigi/pull/2314) Fix navigation context for special iframes ([@hardl](https://github.com/hardl))
-* [#2253](https://github.com/SAP/luigi/pull/2253) Fix wc and splitview wc opened together ([@ndricimrr](https://github.com/ndricimrr))
+* [#2306](https://github.com/luigi-project/luigi/pull/2306) Fixing cursor for a "Fiori3" Profile Dropdown in Shellbar ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2314](https://github.com/luigi-project/luigi/pull/2314) Fix navigation context for special iframes ([@hardl](https://github.com/hardl))
+* [#2253](https://github.com/luigi-project/luigi/pull/2253) Fix wc and splitview wc opened together ([@ndricimrr](https://github.com/ndricimrr))
 
 
 ## [v1.16.2] (2021-09-22)
 
 #### :bug: Fixed
-* [#2284](https://github.com/SAP/luigi/pull/2284) Fix error on modal creation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2284](https://github.com/luigi-project/luigi/pull/2284) Fix error on modal creation ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -785,14 +785,14 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.16.1] (2021-09-09)
 
 #### :rocket: Added
-* [#2236](https://github.com/SAP/luigi/pull/2236) Microfrontend access to query params ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2207](https://github.com/SAP/luigi/pull/2207) Routing core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2236](https://github.com/luigi-project/luigi/pull/2236) Microfrontend access to query params ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2207](https://github.com/luigi-project/luigi/pull/2207) Routing core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
-* [#2262](https://github.com/SAP/luigi/pull/2262) Fix no-animation if #app is not found ([@hardl](https://github.com/hardl))
-* [#2263](https://github.com/SAP/luigi/pull/2263) Fix newTab navigation with hash routing enabled bug ([@ndricimrr](https://github.com/ndricimrr))
-* [#2258](https://github.com/SAP/luigi/pull/2258) Fix goBack with dynamic node functionality ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2252](https://github.com/SAP/luigi/pull/2252) Fix wrong context from modal ([@stanleychh](https://github.com/stanleychh))
+* [#2262](https://github.com/luigi-project/luigi/pull/2262) Fix no-animation if #app is not found ([@hardl](https://github.com/hardl))
+* [#2263](https://github.com/luigi-project/luigi/pull/2263) Fix newTab navigation with hash routing enabled bug ([@ndricimrr](https://github.com/ndricimrr))
+* [#2258](https://github.com/luigi-project/luigi/pull/2258) Fix goBack with dynamic node functionality ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2252](https://github.com/luigi-project/luigi/pull/2252) Fix wrong context from modal ([@stanleychh](https://github.com/stanleychh))
 
 
 
@@ -800,20 +800,20 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.16.0] (2021-08-27)
 
 #### :rocket: Added
-* [#2226](https://github.com/SAP/luigi/pull/2226) Make navigateToIntent parameters optional ([@ndricimrr](https://github.com/ndricimrr))
-* [#2196](https://github.com/SAP/luigi/pull/2196) Extend intent based navigation ([@ndricimrr](https://github.com/ndricimrr))
-* [#2190](https://github.com/SAP/luigi/pull/2190) Add newTab option to linkManager ([@ndricimrr](https://github.com/ndricimrr))
-* [#2173](https://github.com/SAP/luigi/pull/2173) Node title resolver nav up ([@hardl](https://github.com/hardl))
-* [#2177](https://github.com/SAP/luigi/pull/2177) Enable addNavHrefs to be applied to the App Dropdown in TopNav ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2172](https://github.com/SAP/luigi/pull/2172) Add possibility to enable product switch to be opened in new Tab  ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2226](https://github.com/luigi-project/luigi/pull/2226) Make navigateToIntent parameters optional ([@ndricimrr](https://github.com/ndricimrr))
+* [#2196](https://github.com/luigi-project/luigi/pull/2196) Extend intent based navigation ([@ndricimrr](https://github.com/ndricimrr))
+* [#2190](https://github.com/luigi-project/luigi/pull/2190) Add newTab option to linkManager ([@ndricimrr](https://github.com/ndricimrr))
+* [#2173](https://github.com/luigi-project/luigi/pull/2173) Node title resolver nav up ([@hardl](https://github.com/hardl))
+* [#2177](https://github.com/luigi-project/luigi/pull/2177) Enable addNavHrefs to be applied to the App Dropdown in TopNav ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2172](https://github.com/luigi-project/luigi/pull/2172) Add possibility to enable product switch to be opened in new Tab  ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
-* [#2224](https://github.com/SAP/luigi/pull/2224) Fixed global search on smal devices ([@rafalgamon](https://github.com/rafalgamon))
-* [#2220](https://github.com/SAP/luigi/pull/2220) Remove red and purple underline from GlobalNav ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2195](https://github.com/SAP/luigi/pull/2195) Fix Positioning for spinner modal container ([@Patil2099](https://github.com/Patil2099))
+* [#2224](https://github.com/luigi-project/luigi/pull/2224) Fixed global search on smal devices ([@rafalgamon](https://github.com/rafalgamon))
+* [#2220](https://github.com/luigi-project/luigi/pull/2220) Remove red and purple underline from GlobalNav ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2195](https://github.com/luigi-project/luigi/pull/2195) Fix Positioning for spinner modal container ([@Patil2099](https://github.com/Patil2099))
 
 #### :house: Internal
-* [#2230](https://github.com/SAP/luigi/pull/2230) Fix & Re-Enable Docu Generation ([@ndricimrr](https://github.com/ndricimrr))
+* [#2230](https://github.com/luigi-project/luigi/pull/2230) Fix & Re-Enable Docu Generation ([@ndricimrr](https://github.com/ndricimrr))
 
 
 
@@ -823,14 +823,14 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.15.0] (2021-08-05)
 
 #### :rocket: Added
-* [#2168](https://github.com/SAP/luigi/pull/2168) Add navHref support for profile dropdown ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2167](https://github.com/SAP/luigi/pull/2167) Handle runtime errors on core level ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2166](https://github.com/SAP/luigi/pull/2166) Add addNavHref support for TopNav  ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2154](https://github.com/SAP/luigi/pull/2154) Add addNavHref support for GlobalNav ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2168](https://github.com/luigi-project/luigi/pull/2168) Add navHref support for profile dropdown ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2167](https://github.com/luigi-project/luigi/pull/2167) Handle runtime errors on core level ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2166](https://github.com/luigi-project/luigi/pull/2166) Add addNavHref support for TopNav  ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2154](https://github.com/luigi-project/luigi/pull/2154) Add addNavHref support for GlobalNav ([@wdoberschuetz](https://github.com/wdoberschuetz))
 
 #### :bug: Fixed
-* [#2170](https://github.com/SAP/luigi/pull/2170) Fixed Web Component works as drawer ([@rafalgamon](https://github.com/rafalgamon))
-* [#2159](https://github.com/SAP/luigi/pull/2159) Fixed splitview bottom not adjusting to fiddle footer ([@rafalgamon](https://github.com/rafalgamon))
+* [#2170](https://github.com/luigi-project/luigi/pull/2170) Fixed Web Component works as drawer ([@rafalgamon](https://github.com/rafalgamon))
+* [#2159](https://github.com/luigi-project/luigi/pull/2159) Fixed splitview bottom not adjusting to fiddle footer ([@rafalgamon](https://github.com/rafalgamon))
 
 
 
@@ -838,27 +838,27 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 ## [v1.14.3] (2021-07-21)
 
 #### :bug: Fixed
-* [#2163](https://github.com/SAP/luigi/pull/2163) Bug fix navigation to home ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#2164](https://github.com/SAP/luigi/pull/2164) Bug fix initials undefined ([@hardl](https://github.com/hardl))
+* [#2163](https://github.com/luigi-project/luigi/pull/2163) Bug fix navigation to home ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#2164](https://github.com/luigi-project/luigi/pull/2164) Bug fix initials undefined ([@hardl](https://github.com/hardl))
 
 
 
 ## [v1.14.2] (2021-07-15)
 
 #### :bug: Fixed
-* [#2155](https://github.com/SAP/luigi/pull/2155) added compound view to condition ([@hardl](https://github.com/hardl))
+* [#2155](https://github.com/luigi-project/luigi/pull/2155) added compound view to condition ([@hardl](https://github.com/hardl))
 
 
 
 ## [v1.14.1] (2021-07-14)
 
 #### :bug: Fixed
-* [#2129](https://github.com/SAP/luigi/pull/2129) Disable left nav animation when switching from/to mfe with hideSideNav ([@wdoberschuetz](https://github.com/wdoberschuetz))
-* [#2139](https://github.com/SAP/luigi/pull/2139) Prevent to open a node w/o children and empty viewUrl ([@stanleychh](https://github.com/stanleychh))
-* [#2147](https://github.com/SAP/luigi/pull/2147) Fix split view overlapping global nav ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2142](https://github.com/SAP/luigi/pull/2142) Fix issue with hidden text in new user menu ([@UlianaMunich](https://github.com/UlianaMunich))
-* [#2127](https://github.com/SAP/luigi/pull/2127) fix left nav scrollbar ([@hardl](https://github.com/hardl))
-* [#2126](https://github.com/SAP/luigi/pull/2126) Add global variables and rules to adapt App Title for mobile and Tablet ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2129](https://github.com/luigi-project/luigi/pull/2129) Disable left nav animation when switching from/to mfe with hideSideNav ([@wdoberschuetz](https://github.com/wdoberschuetz))
+* [#2139](https://github.com/luigi-project/luigi/pull/2139) Prevent to open a node w/o children and empty viewUrl ([@stanleychh](https://github.com/stanleychh))
+* [#2147](https://github.com/luigi-project/luigi/pull/2147) Fix split view overlapping global nav ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2142](https://github.com/luigi-project/luigi/pull/2142) Fix issue with hidden text in new user menu ([@UlianaMunich](https://github.com/UlianaMunich))
+* [#2127](https://github.com/luigi-project/luigi/pull/2127) fix left nav scrollbar ([@hardl](https://github.com/hardl))
+* [#2126](https://github.com/luigi-project/luigi/pull/2126) Add global variables and rules to adapt App Title for mobile and Tablet ([@UlianaMunich](https://github.com/UlianaMunich))
 
 
 
@@ -866,221 +866,221 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 
 #### :rocket: Added
 
-- [#2074](https://github.com/SAP/luigi/pull/2074) Update FD Styles from v0.17 to v0.18 ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#2088](https://github.com/SAP/luigi/pull/2088) Extend Luigi Emulator functionality ([@ndricimrr](https://github.com/ndricimrr))
-- [#2089](https://github.com/SAP/luigi/pull/2089) Add user settings placeholder ([@rafalgamon](https://github.com/rafalgamon))
-- [#2092](https://github.com/SAP/luigi/pull/2092) Reset luigi via core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#2074](https://github.com/luigi-project/luigi/pull/2074) Update FD Styles from v0.17 to v0.18 ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#2088](https://github.com/luigi-project/luigi/pull/2088) Extend Luigi Emulator functionality ([@ndricimrr](https://github.com/ndricimrr))
+- [#2089](https://github.com/luigi-project/luigi/pull/2089) Add user settings placeholder ([@rafalgamon](https://github.com/rafalgamon))
+- [#2092](https://github.com/luigi-project/luigi/pull/2092) Reset luigi via core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#2094](https://github.com/SAP/luigi/pull/2094) Fix hardcode LogoTitle aria-label and alt text ([@rafalgamon](https://github.com/rafalgamon))
-- [#2081](https://github.com/SAP/luigi/pull/2081) Make Logo and App title an anchor in Shellbar ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#2084](https://github.com/SAP/luigi/pull/2084) WC nested fix ([@hardl](https://github.com/hardl))
+- [#2094](https://github.com/luigi-project/luigi/pull/2094) Fix hardcode LogoTitle aria-label and alt text ([@rafalgamon](https://github.com/rafalgamon))
+- [#2081](https://github.com/luigi-project/luigi/pull/2081) Make Logo and App title an anchor in Shellbar ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#2084](https://github.com/luigi-project/luigi/pull/2084) WC nested fix ([@hardl](https://github.com/hardl))
 
 ## [v1.13.0](2021-06-07)
 
 #### :boom: Breaking Change
 
-- [#1996](https://github.com/SAP/luigi/pull/1996) Update Fundamental Styles library from v0.14.0 to v0.17.0 ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1996](https://github.com/luigi-project/luigi/pull/1996) Update Fundamental Styles library from v0.14.0 to v0.17.0 ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :rocket: Added
 
-- [#2049](https://github.com/SAP/luigi/pull/2049) Extend options of enum type in user settings ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#2040](https://github.com/SAP/luigi/pull/2040) Luigi context emulation in e2e for microfrontends ([@ndricimrr](https://github.com/ndricimrr))
-- [#1996](https://github.com/SAP/luigi/pull/1996) Update Fundamental Styles library from v0.14.0 to v0.17.0 ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#2011](https://github.com/SAP/luigi/pull/2011) Dispatch hashchange event ([@hardl](https://github.com/hardl))
-- [#1995](https://github.com/SAP/luigi/pull/1995) Introduce i18n variable in viewUrl ([@stanleychh](https://github.com/stanleychh))
-- [#1976](https://github.com/SAP/luigi/pull/1976) Disable browser history option ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#2049](https://github.com/luigi-project/luigi/pull/2049) Extend options of enum type in user settings ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#2040](https://github.com/luigi-project/luigi/pull/2040) Luigi context emulation in e2e for microfrontends ([@ndricimrr](https://github.com/ndricimrr))
+- [#1996](https://github.com/luigi-project/luigi/pull/1996) Update Fundamental Styles library from v0.14.0 to v0.17.0 ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#2011](https://github.com/luigi-project/luigi/pull/2011) Dispatch hashchange event ([@hardl](https://github.com/hardl))
+- [#1995](https://github.com/luigi-project/luigi/pull/1995) Introduce i18n variable in viewUrl ([@stanleychh](https://github.com/stanleychh))
+- [#1976](https://github.com/luigi-project/luigi/pull/1976) Disable browser history option ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#2064](https://github.com/SAP/luigi/pull/2064) Route null fix ([@munikumar604](https://github.com/munikumar604))
-- [#2065](https://github.com/SAP/luigi/pull/2065) Path exists fix ([@hardl](https://github.com/hardl))
-- [#2043](https://github.com/SAP/luigi/pull/2043) LuigiAutoRoutingService bug fix ([@hardl](https://github.com/hardl))
-- [#1987](https://github.com/SAP/luigi/pull/1987) Confirmation modal not visible ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1991](https://github.com/SAP/luigi/pull/1991) Make current iframe inactive when switch to wc ([@hardl](https://github.com/hardl))
-- [#1977](https://github.com/SAP/luigi/pull/1977) Fix issue with styling active tab ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1975](https://github.com/SAP/luigi/pull/1975) Fix undefined bug in virtualTree warning ([@ndricimrr](https://github.com/ndricimrr))
+- [#2064](https://github.com/luigi-project/luigi/pull/2064) Route null fix ([@munikumar604](https://github.com/munikumar604))
+- [#2065](https://github.com/luigi-project/luigi/pull/2065) Path exists fix ([@hardl](https://github.com/hardl))
+- [#2043](https://github.com/luigi-project/luigi/pull/2043) LuigiAutoRoutingService bug fix ([@hardl](https://github.com/hardl))
+- [#1987](https://github.com/luigi-project/luigi/pull/1987) Confirmation modal not visible ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1991](https://github.com/luigi-project/luigi/pull/1991) Make current iframe inactive when switch to wc ([@hardl](https://github.com/hardl))
+- [#1977](https://github.com/luigi-project/luigi/pull/1977) Fix issue with styling active tab ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1975](https://github.com/luigi-project/luigi/pull/1975) Fix undefined bug in virtualTree warning ([@ndricimrr](https://github.com/ndricimrr))
 
 ## [v1.12.1](2021-04-01)
 
 #### :rocket: Added
 
-- [#1958](https://github.com/SAP/luigi/pull/1958) Use Byline component for user settings dialog ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1949](https://github.com/SAP/luigi/pull/1949) Normalize link paths ([@hardl](https://github.com/hardl))
+- [#1958](https://github.com/luigi-project/luigi/pull/1958) Use Byline component for user settings dialog ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1949](https://github.com/luigi-project/luigi/pull/1949) Normalize link paths ([@hardl](https://github.com/hardl))
 
 #### :bug: Fixed
 
-- [#1967](https://github.com/SAP/luigi/pull/1967) Limit max-width of Application title only on mobile ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1953](https://github.com/SAP/luigi/pull/1953) Fix context update bug ([@ndricimrr](https://github.com/ndricimrr))
-- [#1926](https://github.com/SAP/luigi/pull/1926) Show Application title on mobile as well ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1967](https://github.com/luigi-project/luigi/pull/1967) Limit max-width of Application title only on mobile ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1953](https://github.com/luigi-project/luigi/pull/1953) Fix context update bug ([@ndricimrr](https://github.com/ndricimrr))
+- [#1926](https://github.com/luigi-project/luigi/pull/1926) Show Application title on mobile as well ([@UlianaMunich](https://github.com/UlianaMunich))
 
 ## [v1.12.0](2021-03-24)
 
 #### :rocket: Added
 
-- [#1841](https://github.com/SAP/luigi/pull/1841) Bookmarkable modals ([@maxmarkus](https://github.com/maxmarkus))
-- [#1935](https://github.com/SAP/luigi/pull/1935) Add warning if both virtualTree and children nodes are defined ([@ndricimrr](https://github.com/ndricimrr))
-- [#1894](https://github.com/SAP/luigi/pull/1894) Add more flexibility to control handshake ([@legteodav](https://github.com/legteodav))
+- [#1841](https://github.com/luigi-project/luigi/pull/1841) Bookmarkable modals ([@maxmarkus](https://github.com/maxmarkus))
+- [#1935](https://github.com/luigi-project/luigi/pull/1935) Add warning if both virtualTree and children nodes are defined ([@ndricimrr](https://github.com/ndricimrr))
+- [#1894](https://github.com/luigi-project/luigi/pull/1894) Add more flexibility to control handshake ([@legteodav](https://github.com/legteodav))
 
 #### :bug: Fixed
 
-- [#1942](https://github.com/SAP/luigi/pull/1942) Fix 'disabled loadingIndicator' bug when opening in modal ([@ndricimrr](https://github.com/ndricimrr))
-- [#1916](https://github.com/SAP/luigi/pull/1916) Shell header improvements ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1912](https://github.com/SAP/luigi/pull/1912) Change color of active link ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1942](https://github.com/luigi-project/luigi/pull/1942) Fix 'disabled loadingIndicator' bug when opening in modal ([@ndricimrr](https://github.com/ndricimrr))
+- [#1916](https://github.com/luigi-project/luigi/pull/1916) Shell header improvements ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1912](https://github.com/luigi-project/luigi/pull/1912) Change color of active link ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## [v1.11.0](2021-03-01)
 
 #### :rocket: Added
 
-- [#1900](https://github.com/SAP/luigi/pull/1900) Confirmation modal enhancements ([@stanleychh](https://github.com/stanleychh))
-- [#1900](https://github.com/SAP/luigi/pull/1884) Apply guidelines for user settings dialog ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1900](https://github.com/luigi-project/luigi/pull/1900) Confirmation modal enhancements ([@stanleychh](https://github.com/stanleychh))
+- [#1900](https://github.com/luigi-project/luigi/pull/1884) Apply guidelines for user settings dialog ([@UlianaMunich](https://github.com/UlianaMunich))
 
 ## [v1.10.0](2021-02-11)
 
 #### :rocket: Added
 
-- [#1854](https://github.com/SAP/luigi/pull/1854) Different visual appearances for boolean#1768 ([@legteodav](https://github.com/legteodav))
-- [#1863](https://github.com/SAP/luigi/pull/1863) Support types for confirmation modal ([@stanleychh](https://github.com/stanleychh))
+- [#1854](https://github.com/luigi-project/luigi/pull/1854) Different visual appearances for boolean#1768 ([@legteodav](https://github.com/legteodav))
+- [#1863](https://github.com/luigi-project/luigi/pull/1863) Support types for confirmation modal ([@stanleychh](https://github.com/stanleychh))
 
 #### :bug: Fixed
 
-- [#1861](https://github.com/SAP/luigi/pull/1861) Error handling for user settings dialog ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1883](https://github.com/SAP/luigi/pull/1883) Bugfix in read/write custom function in luigi user settings config([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1861](https://github.com/luigi-project/luigi/pull/1861) Error handling for user settings dialog ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1883](https://github.com/luigi-project/luigi/pull/1883) Bugfix in read/write custom function in luigi user settings config([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## [v1.9.0](2021-02-05)
 
 #### :boom: Breaking Change
 
-- [#1805](https://github.com/SAP/luigi/pull/1805) Update Core fundamental styles from v.11 to v.14 ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1805](https://github.com/luigi-project/luigi/pull/1805) Update Core fundamental styles from v.11 to v.14 ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :rocket: Added
 
-- [#1833](https://github.com/SAP/luigi/pull/1833) Move user settings config to an own section ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1744](https://github.com/SAP/luigi/pull/1744) Provide a e2e test for "withoutSync()" bug fix ([@legteodav](https://github.com/legteodav))
+- [#1833](https://github.com/luigi-project/luigi/pull/1833) Move user settings config to an own section ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1744](https://github.com/luigi-project/luigi/pull/1744) Provide a e2e test for "withoutSync()" bug fix ([@legteodav](https://github.com/legteodav))
 
 #### :bug: Fixed
 
-- [#1859](https://github.com/SAP/luigi/pull/1859) Change Profile Avatar layout and logic ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1859](https://github.com/luigi-project/luigi/pull/1859) Change Profile Avatar layout and logic ([@UlianaMunich](https://github.com/UlianaMunich))
 
 ## [v1.8.1](2021-01-27)
 
 #### :bug: Fixed
 
-- [#1840](https://github.com/SAP/luigi/pull/1840) Fixed OIDC Implicit Flow id_token Issue ([@hardl](https://github.com/hardl))
-- [#1849](https://github.com/SAP/luigi/pull/1849) Fix Loading Indicator Fixed Background Color ([@legteodav](https://github.com/legteodav))
+- [#1840](https://github.com/luigi-project/luigi/pull/1840) Fixed OIDC Implicit Flow id_token Issue ([@hardl](https://github.com/hardl))
+- [#1849](https://github.com/luigi-project/luigi/pull/1849) Fix Loading Indicator Fixed Background Color ([@legteodav](https://github.com/legteodav))
 
 ## [v1.8.0](2021-01-21)
 
 #### :rocket: Added
 
-- [#1802](https://github.com/SAP/luigi/pull/1802) Custom Micro-Frontend for User Settings ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1821](https://github.com/SAP/luigi/pull/1821) Fix Styling of User Name in Profile Dropdown ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1790](https://github.com/SAP/luigi/pull/1790) Add Different Visual Appearances for Enums ([@legteodav](https://github.com/legteodav))
-- [#1809](https://github.com/SAP/luigi/pull/1809) Add ng Support Library Enhancements ([@hardl](https://github.com/hardl))
-- [#1799](https://github.com/SAP/luigi/pull/1799) Make navigateIframe and prepareInternalData Functions be Async ([@stanleychh](https://github.com/stanleychh))
+- [#1802](https://github.com/luigi-project/luigi/pull/1802) Custom Micro-Frontend for User Settings ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1821](https://github.com/luigi-project/luigi/pull/1821) Fix Styling of User Name in Profile Dropdown ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1790](https://github.com/luigi-project/luigi/pull/1790) Add Different Visual Appearances for Enums ([@legteodav](https://github.com/legteodav))
+- [#1809](https://github.com/luigi-project/luigi/pull/1809) Add ng Support Library Enhancements ([@hardl](https://github.com/hardl))
+- [#1799](https://github.com/luigi-project/luigi/pull/1799) Make navigateIframe and prepareInternalData Functions be Async ([@stanleychh](https://github.com/stanleychh))
 
 #### :bug: Fixed
 
-- [#1814](https://github.com/SAP/luigi/pull/1814) OIDC Client State Fix ([@hardl](https://github.com/hardl))
+- [#1814](https://github.com/luigi-project/luigi/pull/1814) OIDC Client State Fix ([@hardl](https://github.com/hardl))
 
 ## [v1.7.1](2020-12-23) :christmas_tree: :santa: :gift:
 
 #### :rocket: Added
 
-- [#1761](https://github.com/SAP/luigi/pull/1761) multi-level keepSelectedForChildren ([@hardl](https://github.com/hardl))
-- [#1753](https://github.com/SAP/luigi/pull/1753) Global search enhancements ([@legteodav](https://github.com/legteodav))
+- [#1761](https://github.com/luigi-project/luigi/pull/1761) multi-level keepSelectedForChildren ([@hardl](https://github.com/hardl))
+- [#1753](https://github.com/luigi-project/luigi/pull/1753) Global search enhancements ([@legteodav](https://github.com/legteodav))
 
 #### :bug: Fixed
 
-- [#1765](https://github.com/SAP/luigi/pull/1765) Fix drawer undefined bug ([@ndricimrr](https://github.com/ndricimrr))
-- [#1784](https://github.com/SAP/luigi/pull/1784) Browser history fix ([@hardl](https://github.com/hardl))
+- [#1765](https://github.com/luigi-project/luigi/pull/1765) Fix drawer undefined bug ([@ndricimrr](https://github.com/ndricimrr))
+- [#1784](https://github.com/luigi-project/luigi/pull/1784) Browser history fix ([@hardl](https://github.com/hardl))
 
 ## v1.7.0 (2020-12-04)
 
 #### :rocket: Added
 
-- [#1756](https://github.com/SAP/luigi/pull/1756) Feature - Angular supporting library ([@legteodav](https://github.com/legteodav))
-- [#1751](https://github.com/SAP/luigi/pull/1751) Feature - WebComponents support ([@hardl](https://github.com/hardl))
+- [#1756](https://github.com/luigi-project/luigi/pull/1756) Feature - Angular supporting library ([@legteodav](https://github.com/legteodav))
+- [#1751](https://github.com/luigi-project/luigi/pull/1751) Feature - WebComponents support ([@hardl](https://github.com/hardl))
 
 #### :bug: Fixed
 
-- [#1720](https://github.com/SAP/luigi/pull/1720) Fix `withoutSync()` history behaviour ([@andrei-scripcaru](https://github.com/andrei-scripcaru))
+- [#1720](https://github.com/luigi-project/luigi/pull/1720) Fix `withoutSync()` history behaviour ([@andrei-scripcaru](https://github.com/andrei-scripcaru))
 
 #### :house: Internal
 
-- [#1734](https://github.com/SAP/luigi/pull/1734) Documentation website using Luigi.globalSearch() API (#1690) ([@legteodav](https://github.com/legteodav))
+- [#1734](https://github.com/luigi-project/luigi/pull/1734) Documentation website using Luigi.globalSearch() API (#1690) ([@legteodav](https://github.com/legteodav))
 
 ## [v1.6.0](2020-11-25)
 
 #### :rocket: Added
 
-- [#1707](https://github.com/SAP/luigi/pull/1707) Simple storage api for micro frontends ([@legteodav](https://github.com/legteodav))
-- [#1704](https://github.com/SAP/luigi/pull/1704) Add openNodeInModal attribute to Profile section of the documentation ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1659](https://github.com/SAP/luigi/pull/1659) Add drawer component ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1707](https://github.com/luigi-project/luigi/pull/1707) Simple storage api for micro frontends ([@legteodav](https://github.com/legteodav))
+- [#1704](https://github.com/luigi-project/luigi/pull/1704) Add openNodeInModal attribute to Profile section of the documentation ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1659](https://github.com/luigi-project/luigi/pull/1659) Add drawer component ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#1716](https://github.com/SAP/luigi/pull/1716) Remove default outline for iframeContainer ([@legteodav](https://github.com/legteodav))
-- [#1689](https://github.com/SAP/luigi/pull/1689) Safari bug with shellbar dropdowns blue outlie ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1716](https://github.com/luigi-project/luigi/pull/1716) Remove default outline for iframeContainer ([@legteodav](https://github.com/legteodav))
+- [#1689](https://github.com/luigi-project/luigi/pull/1689) Safari bug with shellbar dropdowns blue outlie ([@UlianaMunich](https://github.com/UlianaMunich))
 
 ## [v1.5.0](2020-10-28)
 
 #### :rocket: Added
 
-- [#1634](https://github.com/SAP/luigi/pull/1634) Implement intent based navigation ([@ndricimrr](https://github.com/ndricimrr))
-- [#1652](https://github.com/SAP/luigi/pull/1652) Expose login method in core api([@ionutcirja](https://github.com/ionutcirja))
-- [#1631](https://github.com/SAP/luigi/pull/1631) Updating Auth API to allow dynamic logout ([@dangrima90](https://github.com/dangrima90))
-- [#1623](https://github.com/SAP/luigi/pull/1623) Add accordion effect to categories ([@azriel46d](https://github.com/azriel46d))
-- [#1620](https://github.com/SAP/luigi/pull/1620) Add disableInputHelpers for globalsearch ([@maxmarkus](https://github.com/maxmarkus))
-- [#1665](https://github.com/SAP/luigi/pull/1665) Enable collapsed left side navigation via Core API ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1634](https://github.com/luigi-project/luigi/pull/1634) Implement intent based navigation ([@ndricimrr](https://github.com/ndricimrr))
+- [#1652](https://github.com/luigi-project/luigi/pull/1652) Expose login method in core api([@ionutcirja](https://github.com/ionutcirja))
+- [#1631](https://github.com/luigi-project/luigi/pull/1631) Updating Auth API to allow dynamic logout ([@dangrima90](https://github.com/dangrima90))
+- [#1623](https://github.com/luigi-project/luigi/pull/1623) Add accordion effect to categories ([@azriel46d](https://github.com/azriel46d))
+- [#1620](https://github.com/luigi-project/luigi/pull/1620) Add disableInputHelpers for globalsearch ([@maxmarkus](https://github.com/maxmarkus))
+- [#1665](https://github.com/luigi-project/luigi/pull/1665) Enable collapsed left side navigation via Core API ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
 
-- [#1665](https://github.com/SAP/luigi/pull/1665) Fix bug in nav collapsed state ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1671](https://github.com/SAP/luigi/pull/1671) Fix bug IE11 domain check ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1675](https://github.com/SAP/luigi/pull/1675) Prevent to open a second splitview from LuigiClient ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1641](https://github.com/SAP/luigi/pull/1641) Close splitview after navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1633](https://github.com/SAP/luigi/pull/1633) Fix issues with broken left side nav in semiCollapsed mode and scroller ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1640](https://github.com/SAP/luigi/pull/1640) Fixed nav hrefs for hash routing ([@hardl](https://github.com/hardl))
-- [#1624](https://github.com/SAP/luigi/pull/1624) Fix modal content not displaying issue in Safari ([@stanleychh](https://github.com/stanleychh))
+- [#1665](https://github.com/luigi-project/luigi/pull/1665) Fix bug in nav collapsed state ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1671](https://github.com/luigi-project/luigi/pull/1671) Fix bug IE11 domain check ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1675](https://github.com/luigi-project/luigi/pull/1675) Prevent to open a second splitview from LuigiClient ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1641](https://github.com/luigi-project/luigi/pull/1641) Close splitview after navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1633](https://github.com/luigi-project/luigi/pull/1633) Fix issues with broken left side nav in semiCollapsed mode and scroller ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1640](https://github.com/luigi-project/luigi/pull/1640) Fixed nav hrefs for hash routing ([@hardl](https://github.com/hardl))
+- [#1624](https://github.com/luigi-project/luigi/pull/1624) Fix modal content not displaying issue in Safari ([@stanleychh](https://github.com/stanleychh))
 
 ## [v1.4.0](2020-09-09)
 
 #### :rocket: Added
 
-- [#1611](https://github.com/SAP/luigi/pull/1611) Theming API ([@maxmarkus](https://github.com/maxmarkus))
-- [#1591](https://github.com/SAP/luigi/pull/1591) Possibility to set document title without Luigi header config ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1578](https://github.com/SAP/luigi/pull/1578) Modal loading indicator and close Modal event ([@azriel46d](https://github.com/azriel46d))
-- [#1579](https://github.com/SAP/luigi/pull/1579) Luigi sample with NextJs ([@stanleychh](https://github.com/stanleychh))
-- [#1571](https://github.com/SAP/luigi/pull/1571) Feature toggles ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1542](https://github.com/SAP/luigi/issues/1542) Update Fundamental Styles library to 0.11.0 ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1611](https://github.com/luigi-project/luigi/pull/1611) Theming API ([@maxmarkus](https://github.com/maxmarkus))
+- [#1591](https://github.com/luigi-project/luigi/pull/1591) Possibility to set document title without Luigi header config ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1578](https://github.com/luigi-project/luigi/pull/1578) Modal loading indicator and close Modal event ([@azriel46d](https://github.com/azriel46d))
+- [#1579](https://github.com/luigi-project/luigi/pull/1579) Luigi sample with NextJs ([@stanleychh](https://github.com/stanleychh))
+- [#1571](https://github.com/luigi-project/luigi/pull/1571) Feature toggles ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1542](https://github.com/luigi-project/luigi/issues/1542) Update Fundamental Styles library to 0.11.0 ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
 
-- [#1565](https://github.com/SAP/luigi/pull/1565) Fix for content security policy issues ([@maxmarkus](https://github.com/maxmarkus))
-- [#1612](https://github.com/SAP/luigi/pull/1612) Fix issue with dotted outline in the left side nav ([@UlianaMunich](https://github.com/UlianaMunich))
-- [#1606](https://github.com/SAP/luigi/pull/1606) Fix shellbar buttons alignment issue ([@stanleychh](https://github.com/stanleychh))
-- [#1587](https://github.com/SAP/luigi/pull/1587) Add up arrow key press to global search ([@stanleychh](https://github.com/stanleychh))
-- [#1580](https://github.com/SAP/luigi/pull/1580) Iframe handshake sync ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1565](https://github.com/luigi-project/luigi/pull/1565) Fix for content security policy issues ([@maxmarkus](https://github.com/maxmarkus))
+- [#1612](https://github.com/luigi-project/luigi/pull/1612) Fix issue with dotted outline in the left side nav ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1606](https://github.com/luigi-project/luigi/pull/1606) Fix shellbar buttons alignment issue ([@stanleychh](https://github.com/stanleychh))
+- [#1587](https://github.com/luigi-project/luigi/pull/1587) Add up arrow key press to global search ([@stanleychh](https://github.com/stanleychh))
+- [#1580](https://github.com/luigi-project/luigi/pull/1580) Iframe handshake sync ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## [v1.3.1](2020-08-14)
 
 #### :bug: Fixed
 
-- [#1514](https://github.com/SAP/luigi/pull/1514) Fix a border-radius bug in nested list for 'Select Environment' popover ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1514](https://github.com/luigi-project/luigi/pull/1514) Fix a border-radius bug in nested list for 'Select Environment' popover ([@UlianaMunich](https://github.com/UlianaMunich))
 
 ## [v1.3.0](2020-07-16)
 
 #### :rocket: Added
 
-- [#1496](https://github.com/SAP/luigi/pull/1496) NEW: Global search ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1478](https://github.com/SAP/luigi/pull/1478) OIDC Support for Authorization Code flow with PKCE ([@azriel46d](https://github.com/azriel46d))
+- [#1496](https://github.com/luigi-project/luigi/pull/1496) NEW: Global search ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1478](https://github.com/luigi-project/luigi/pull/1478) OIDC Support for Authorization Code flow with PKCE ([@azriel46d](https://github.com/azriel46d))
 
 #### :bug: Fixed
 
-- [#1477](https://github.com/SAP/luigi/pull/1477) ContextSwitcher fix selected state ([@maxmarkus](https://github.com/maxmarkus))
-- [#1441](https://github.com/SAP/luigi/pull/1441) Navigation with and without params on the same node ([@ndricimrr](https://github.com/ndricimrr))
+- [#1477](https://github.com/luigi-project/luigi/pull/1477) ContextSwitcher fix selected state ([@maxmarkus](https://github.com/maxmarkus))
+- [#1441](https://github.com/luigi-project/luigi/pull/1441) Navigation with and without params on the same node ([@ndricimrr](https://github.com/ndricimrr))
 
 > With Luigi version v1.3.0, the new v0.10.0 of Fundamental Library Styles were included. As a result, there were breaking changes to the Luigi side navigation. You can see the updated layout [here](https://sap.github.io/fundamental-styles/?path=/docs/sap-fiori-deprecated-components-side-navigation--docs).
 
@@ -1088,20 +1088,20 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 
 #### :bug: Fixed
 
-- [#1453](https://github.com/SAP/luigi/pull/1453) Fix logout label ([@maxmarkus](https://github.com/maxmarkus))
-- [#1431](https://github.com/SAP/luigi/pull/1431) Fix semicollapsible resize ([@maxmarkus](https://github.com/maxmarkus))
+- [#1453](https://github.com/luigi-project/luigi/pull/1453) Fix logout label ([@maxmarkus](https://github.com/maxmarkus))
+- [#1431](https://github.com/luigi-project/luigi/pull/1431) Fix semicollapsible resize ([@maxmarkus](https://github.com/maxmarkus))
 
 ## [v1.2.3](2020-06-26)
 
 #### :rocket: Added
 
-- [#1429](https://github.com/SAP/luigi/pull/1429) Added showLabel attribute to node for top level nav ([@azriel46d](https://github.com/azriel46d))
-- [#1409](https://github.com/SAP/luigi/pull/1409) Added badge counter to left navigation ([@azriel46d](https://github.com/azriel46d))
+- [#1429](https://github.com/luigi-project/luigi/pull/1429) Added showLabel attribute to node for top level nav ([@azriel46d](https://github.com/azriel46d))
+- [#1409](https://github.com/luigi-project/luigi/pull/1409) Added badge counter to left navigation ([@azriel46d](https://github.com/azriel46d))
 
 #### :bug: Fixed
 
-- [#1433](https://github.com/SAP/luigi/pull/1433) Fix double frame ([@hardl](https://github.com/hardl))
-- [#1436](https://github.com/SAP/luigi/pull/1436) Remove window.parent check from Client ([@maxmarkus](https://github.com/maxmarkus))
+- [#1433](https://github.com/luigi-project/luigi/pull/1433) Fix double frame ([@hardl](https://github.com/hardl))
+- [#1436](https://github.com/luigi-project/luigi/pull/1436) Remove window.parent check from Client ([@maxmarkus](https://github.com/maxmarkus))
 
 ## [v1.2.2](2020-06-25)
 
@@ -1111,748 +1111,748 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 
 #### :rocket: Added
 
-- [#1316](https://github.com/SAP/luigi/pull/1316) Add onNodeChange hook ([@zarkosimic](https://github.com/zarkosimic))
-- [#1326](https://github.com/SAP/luigi/pull/1326) Selected state for product switch items ([@hardl](https://github.com/hardl))
-- [#1304](https://github.com/SAP/luigi/pull/1304) Add possibility to unload Luigi ([@maxmarkus](https://github.com/maxmarkus))
+- [#1316](https://github.com/luigi-project/luigi/pull/1316) Add onNodeChange hook ([@zarkosimic](https://github.com/zarkosimic))
+- [#1326](https://github.com/luigi-project/luigi/pull/1326) Selected state for product switch items ([@hardl](https://github.com/hardl))
+- [#1304](https://github.com/luigi-project/luigi/pull/1304) Add possibility to unload Luigi ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#1356](https://github.com/SAP/luigi/pull/1356) Fix client half init state ([@maxmarkus](https://github.com/maxmarkus))
-- [#1374](https://github.com/SAP/luigi/pull/1374) Fix flyout title propagation ([@maxmarkus](https://github.com/maxmarkus))
-- [#1367](https://github.com/SAP/luigi/pull/1367) Add testing production build capability ([@ndricimrr](https://github.com/ndricimrr))
-- [#1364](https://github.com/SAP/luigi/pull/1364) Fix iframe fallback ([@maxmarkus](https://github.com/maxmarkus))
-- [#1376](https://github.com/SAP/luigi/pull/1376) Fix left-nav flyout ([@zarkosimic](https://github.com/zarkosimic))
-- [#1368](https://github.com/SAP/luigi/pull/1368) ContextSwitcher bugfix ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#1335](https://github.com/SAP/luigi/pull/1335) Fix oidc regenerator runtime issue ([@maxmarkus](https://github.com/maxmarkus))
+- [#1356](https://github.com/luigi-project/luigi/pull/1356) Fix client half init state ([@maxmarkus](https://github.com/maxmarkus))
+- [#1374](https://github.com/luigi-project/luigi/pull/1374) Fix flyout title propagation ([@maxmarkus](https://github.com/maxmarkus))
+- [#1367](https://github.com/luigi-project/luigi/pull/1367) Add testing production build capability ([@ndricimrr](https://github.com/ndricimrr))
+- [#1364](https://github.com/luigi-project/luigi/pull/1364) Fix iframe fallback ([@maxmarkus](https://github.com/maxmarkus))
+- [#1376](https://github.com/luigi-project/luigi/pull/1376) Fix left-nav flyout ([@zarkosimic](https://github.com/zarkosimic))
+- [#1368](https://github.com/luigi-project/luigi/pull/1368) ContextSwitcher bugfix ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#1335](https://github.com/luigi-project/luigi/pull/1335) Fix oidc regenerator runtime issue ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#1313](https://github.com/SAP/luigi/pull/1313) Add read-only keyword labels to documentation ([@ndricimrr](https://github.com/ndricimrr))
+- [#1313](https://github.com/luigi-project/luigi/pull/1313) Add read-only keyword labels to documentation ([@ndricimrr](https://github.com/ndricimrr))
 
 ## [v1.1.1](2020-05-07)
 
 #### :rocket: Added
 
-- [#1317](https://github.com/SAP/luigi/pull/1317) Simple core development setup ([@hardl](https://github.com/hardl))
+- [#1317](https://github.com/luigi-project/luigi/pull/1317) Simple core development setup ([@hardl](https://github.com/hardl))
 
 #### :bug: Fixed
 
-- [#1318](https://github.com/SAP/luigi/pull/1318) Fix tabnav active state indication ([@hardl](https://github.com/hardl))
-- [#1278](https://github.com/SAP/luigi/pull/1278) Cache improvements for dynamic nodes ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1318](https://github.com/luigi-project/luigi/pull/1318) Fix tabnav active state indication ([@hardl](https://github.com/hardl))
+- [#1278](https://github.com/luigi-project/luigi/pull/1278) Cache improvements for dynamic nodes ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :memo: Documentation
 
-- [#1284](https://github.com/SAP/luigi/pull/1284) Documentation for Internationalization i18n ([@maxmarkus](https://github.com/maxmarkus))
-- [#1287](https://github.com/SAP/luigi/pull/1287) Link to 0.7.x documentation ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1284](https://github.com/luigi-project/luigi/pull/1284) Documentation for Internationalization i18n ([@maxmarkus](https://github.com/maxmarkus))
+- [#1287](https://github.com/luigi-project/luigi/pull/1287) Link to 0.7.x documentation ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v1.1.0](2020-04-24)
 
 #### :boom: Breaking Change
 
-- [#1267](https://github.com/SAP/luigi/pull/1267) Following an upgrade to Fundamental Library Styles version 0.8.1, there were changes in the HTML structure. Some classes were renamed or removed completely. You can find the full list of Fundamental Library Styles changes [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes). ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#1267](https://github.com/luigi-project/luigi/pull/1267) Following an upgrade to Fundamental Library Styles version 0.8.1, there were changes in the HTML structure. Some classes were renamed or removed completely. You can find the full list of Fundamental Library Styles changes [here](https://github.com/SAP/fundamental-styles/wiki/Breaking-Changes). ([@marynaKhromova](https://github.com/marynaKhromova))
 
 #### :rocket: Added
 
-- [#1283](https://github.com/SAP/luigi/pull/1283) Translate tooltip text in semi collapsed mode and add title attributes to entries in left nav ([@zarkosimic](https://github.com/zarkosimic))
-- [#1269](https://github.com/SAP/luigi/pull/1269) Oidc provider uses storage type also for oidc client configuration ([@maxmarkus](https://github.com/maxmarkus))
-- [#1241](https://github.com/SAP/luigi/pull/1241) Update fundamental styles to 0.8.1 ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1283](https://github.com/luigi-project/luigi/pull/1283) Translate tooltip text in semi collapsed mode and add title attributes to entries in left nav ([@zarkosimic](https://github.com/zarkosimic))
+- [#1269](https://github.com/luigi-project/luigi/pull/1269) Oidc provider uses storage type also for oidc client configuration ([@maxmarkus](https://github.com/maxmarkus))
+- [#1241](https://github.com/luigi-project/luigi/pull/1241) Update fundamental styles to 0.8.1 ([@UlianaMunich](https://github.com/UlianaMunich))
 
 #### :bug: Fixed
 
-- [#1291](https://github.com/SAP/luigi/pull/1291) Fix semicollapsible issue ([@maxmarkus](https://github.com/maxmarkus))
-- [#1271](https://github.com/SAP/luigi/pull/1271) Fix leftnav nav-sync issue ([@maxmarkus](https://github.com/maxmarkus))
-- [#1263](https://github.com/SAP/luigi/pull/1263) Fiddle demo page mobile view ([@UlianaMunich](https://github.com/UlianaMunich))
+- [#1291](https://github.com/luigi-project/luigi/pull/1291) Fix semicollapsible issue ([@maxmarkus](https://github.com/maxmarkus))
+- [#1271](https://github.com/luigi-project/luigi/pull/1271) Fix leftnav nav-sync issue ([@maxmarkus](https://github.com/maxmarkus))
+- [#1263](https://github.com/luigi-project/luigi/pull/1263) Fiddle demo page mobile view ([@UlianaMunich](https://github.com/UlianaMunich))
 
 ## [v1.0.1](2020-04-09)
 
 #### :rocket: Added
 
-- [#1226](https://github.com/SAP/luigi/pull/1226) Add fromVirtualTreeRoot to linkManager ([@maxmarkus](https://github.com/maxmarkus))
-- [#1222](https://github.com/SAP/luigi/pull/1222) Add fromParent to linkManager ([@ndricimrr](https://github.com/ndricimrr))
-- [#1159](https://github.com/SAP/luigi/pull/1159) Getting notified of unresponsive Luigi clients ([@zarkosimic](https://github.com/zarkosimic))
+- [#1226](https://github.com/luigi-project/luigi/pull/1226) Add fromVirtualTreeRoot to linkManager ([@maxmarkus](https://github.com/maxmarkus))
+- [#1222](https://github.com/luigi-project/luigi/pull/1222) Add fromParent to linkManager ([@ndricimrr](https://github.com/ndricimrr))
+- [#1159](https://github.com/luigi-project/luigi/pull/1159) Getting notified of unresponsive Luigi clients ([@zarkosimic](https://github.com/zarkosimic))
 
 #### :bug: Fixed
 
-- [#1251](https://github.com/SAP/luigi/pull/1251) Flyout should close after click ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#1213](https://github.com/SAP/luigi/pull/1213) Fix OIDC storage: none ([@maxmarkus](https://github.com/maxmarkus))
-- [#1220](https://github.com/SAP/luigi/pull/1220) Fix duplicate login logout buttons ([@maxmarkus](https://github.com/maxmarkus))
+- [#1251](https://github.com/luigi-project/luigi/pull/1251) Flyout should close after click ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#1213](https://github.com/luigi-project/luigi/pull/1213) Fix OIDC storage: none ([@maxmarkus](https://github.com/maxmarkus))
+- [#1220](https://github.com/luigi-project/luigi/pull/1220) Fix duplicate login logout buttons ([@maxmarkus](https://github.com/maxmarkus))
 
 ## [v1.0.0](2020-03-26)
 
 #### :rocket: Added
 
-- [#1151](https://github.com/SAP/luigi/pull/1151) Add customSelectedOptionRenderer to style ContextSwitcher dropdown button ([@ndricimrr](https://github.com/ndricimrr))
-- [#1058](https://github.com/SAP/luigi/pull/1058) Refactor authorisation to activate idp providers before Luigi is rendered ([@maxmarkus](https://github.com/maxmarkus))
-- [#1055](https://github.com/SAP/luigi/pull/1055) Externalize auth providers ([@maxmarkus](https://github.com/maxmarkus))
-- [#912](https://github.com/SAP/luigi/issues/912) Switch to fundamental styles ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#1151](https://github.com/luigi-project/luigi/pull/1151) Add customSelectedOptionRenderer to style ContextSwitcher dropdown button ([@ndricimrr](https://github.com/ndricimrr))
+- [#1058](https://github.com/luigi-project/luigi/pull/1058) Refactor authorisation to activate idp providers before Luigi is rendered ([@maxmarkus](https://github.com/maxmarkus))
+- [#1055](https://github.com/luigi-project/luigi/pull/1055) Externalize auth providers ([@maxmarkus](https://github.com/maxmarkus))
+- [#912](https://github.com/luigi-project/luigi/issues/912) Switch to fundamental styles ([@marynaKhromova](https://github.com/marynaKhromova))
 
 #### :bug: Fixed
 
-- [#1189](https://github.com/SAP/luigi/pull/1189) Modal window contrast on dark themes ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#1158](https://github.com/SAP/luigi/pull/1158) Aligned splitview and centered arrow ([@ndricimrr](https://github.com/ndricimrr))
+- [#1189](https://github.com/luigi-project/luigi/pull/1189) Modal window contrast on dark themes ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#1158](https://github.com/luigi-project/luigi/pull/1158) Aligned splitview and centered arrow ([@ndricimrr](https://github.com/ndricimrr))
 
 #### :memo: Documentation
 
-- [#1155](https://github.com/SAP/luigi/pull/1155) Document potential wrong-usage of context/dynamic nodes ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1135](https://github.com/SAP/luigi/pull/1135) Add fundamental library styles section to migration docu ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#1155](https://github.com/luigi-project/luigi/pull/1155) Document potential wrong-usage of context/dynamic nodes ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1135](https://github.com/luigi-project/luigi/pull/1135) Add fundamental library styles section to migration docu ([@marynaKhromova](https://github.com/marynaKhromova))
 
 ## [v0.7.7](2020-03-20)
 
 #### :bug: Fixed
 
-- [#1172](https://github.com/SAP/luigi/pull/1172) Fix virtualtree trailing slash ([@maxmarkus](https://github.com/maxmarkus))
-- [#1179](https://github.com/SAP/luigi/pull/1179) Fix navigate ok check for withoutSync ([@maxmarkus](https://github.com/maxmarkus))
-- [#1173](https://github.com/SAP/luigi/pull/1173) Recalculation after cache deletion ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1148](https://github.com/SAP/luigi/pull/1148) deleteCache was missing in contextswitcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1145](https://github.com/SAP/luigi/pull/1145) Route change loses context in contextswitcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1172](https://github.com/luigi-project/luigi/pull/1172) Fix virtualtree trailing slash ([@maxmarkus](https://github.com/maxmarkus))
+- [#1179](https://github.com/luigi-project/luigi/pull/1179) Fix navigate ok check for withoutSync ([@maxmarkus](https://github.com/maxmarkus))
+- [#1173](https://github.com/luigi-project/luigi/pull/1173) Recalculation after cache deletion ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1148](https://github.com/luigi-project/luigi/pull/1148) deleteCache was missing in contextswitcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1145](https://github.com/luigi-project/luigi/pull/1145) Route change loses context in contextswitcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :memo: Documentation
 
-- [#1060](https://github.com/SAP/luigi/pull/1060) Luigi Videos ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1116](https://github.com/SAP/luigi/pull/1116) Add implementations/scenarios ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1060](https://github.com/luigi-project/luigi/pull/1060) Luigi Videos ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1116](https://github.com/luigi-project/luigi/pull/1116) Add implementations/scenarios ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.7.6](2020-03-09)
 
 #### :rocket: Added
 
-- [#1075](https://github.com/SAP/luigi/pull/1075) Virtual tree navigation ([@maxmarkus](https://github.com/maxmarkus))
-- [#1111](https://github.com/SAP/luigi/pull/1111) Ability to update core URL without micro frontend URL change ([@maxmarkus](https://github.com/maxmarkus))
-- [#1076](https://github.com/SAP/luigi/pull/1076) Core API: Add splitview functionality ([@ndricimrr](https://github.com/ndricimrr))
-- [#1129](https://github.com/SAP/luigi/pull/1129) OpenIdConnect (OIDC) provider profile interceptor ([@maxmarkus](https://github.com/maxmarkus))
+- [#1075](https://github.com/luigi-project/luigi/pull/1075) Virtual tree navigation ([@maxmarkus](https://github.com/maxmarkus))
+- [#1111](https://github.com/luigi-project/luigi/pull/1111) Ability to update core URL without micro frontend URL change ([@maxmarkus](https://github.com/maxmarkus))
+- [#1076](https://github.com/luigi-project/luigi/pull/1076) Core API: Add splitview functionality ([@ndricimrr](https://github.com/ndricimrr))
+- [#1129](https://github.com/luigi-project/luigi/pull/1129) OpenIdConnect (OIDC) provider profile interceptor ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#1119](https://github.com/SAP/luigi/pull/1119) Refactor resolved node children data management ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1115](https://github.com/SAP/luigi/pull/1115) Profile icon tooltip text ([@maxmarkus](https://github.com/maxmarkus))
+- [#1119](https://github.com/luigi-project/luigi/pull/1119) Refactor resolved node children data management ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1115](https://github.com/luigi-project/luigi/pull/1115) Profile icon tooltip text ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#1109](https://github.com/SAP/luigi/pull/1109) Document how to make use of contextUpdateListener ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1096](https://github.com/SAP/luigi/pull/1096) Document how to set auth storage type ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1099](https://github.com/SAP/luigi/pull/1099) Update documentation for examples + consolidate filenames ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1109](https://github.com/luigi-project/luigi/pull/1109) Document how to make use of contextUpdateListener ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1096](https://github.com/luigi-project/luigi/pull/1096) Document how to set auth storage type ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1099](https://github.com/luigi-project/luigi/pull/1099) Update documentation for examples + consolidate filenames ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.7.5](2020-02-14)
 
 #### :rocket: Added
 
-- [#1083](https://github.com/SAP/luigi/pull/1083) Open profile items in a modal window ([@zarkosimic](https://github.com/zarkosimic))
+- [#1083](https://github.com/luigi-project/luigi/pull/1083) Open profile items in a modal window ([@zarkosimic](https://github.com/zarkosimic))
 
 #### :bug: Fixed
 
-- [#1081](https://github.com/SAP/luigi/pull/1081) CustomMessages from external mf does not work ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1068](https://github.com/SAP/luigi/pull/1068) Fix fd-modal mix-up ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1081](https://github.com/luigi-project/luigi/pull/1081) CustomMessages from external mf does not work ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1068](https://github.com/luigi-project/luigi/pull/1068) Fix fd-modal mix-up ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## [v0.7.4](2020-01-29)
 
 #### :rocket: Added
 
-- [#1034](https://github.com/SAP/luigi/pull/1034) Add valid href to navigation links ([@maxmarkus](https://github.com/maxmarkus))
+- [#1034](https://github.com/luigi-project/luigi/pull/1034) Add valid href to navigation links ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#1065](https://github.com/SAP/luigi/pull/1065) Fix items calculation in more btn of tab nav ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1047](https://github.com/SAP/luigi/pull/1047) Custom options renderer config error ([@maxmarkus](https://github.com/maxmarkus))
+- [#1065](https://github.com/luigi-project/luigi/pull/1065) Fix items calculation in more btn of tab nav ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1047](https://github.com/luigi-project/luigi/pull/1047) Custom options renderer config error ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#1025](https://github.com/SAP/luigi/pull/1025) Improve API documentation ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1024](https://github.com/SAP/luigi/pull/1024) Improve authorization doc structure ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1000](https://github.com/SAP/luigi/pull/1000) Improve Overview page ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#965](https://github.com/SAP/luigi/pull/965) Improve application-setup.md ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#877](https://github.com/SAP/luigi/pull/877) Create content guidelines ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#1003](https://github.com/SAP/luigi/pull/1003) Documentation fixes ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1025](https://github.com/luigi-project/luigi/pull/1025) Improve API documentation ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1024](https://github.com/luigi-project/luigi/pull/1024) Improve authorization doc structure ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1000](https://github.com/luigi-project/luigi/pull/1000) Improve Overview page ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#965](https://github.com/luigi-project/luigi/pull/965) Improve application-setup.md ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#877](https://github.com/luigi-project/luigi/pull/877) Create content guidelines ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#1003](https://github.com/luigi-project/luigi/pull/1003) Documentation fixes ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.7.3](2019-12-19)
 
 #### :rocket: Added
 
-- [#1002](https://github.com/SAP/luigi/pull/1002) Implicit structural nodes ([@maxmarkus](https://github.com/maxmarkus))
-- [#1014](https://github.com/SAP/luigi/pull/1014) Disable context switcher drop down caret when there is only one option ([@pekura](https://github.com/pekura))
-- [#1008](https://github.com/SAP/luigi/pull/1008) Custom item renderer for options in context switcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#993](https://github.com/SAP/luigi/pull/993) React setup ([@ndricimrr](https://github.com/ndricimrr))
-- [#994](https://github.com/SAP/luigi/pull/994) Handle init in Luigi client without init handshake ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#1028](https://github.com/SAP/luigi/pull/1028) Add navigation functionality to core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1002](https://github.com/luigi-project/luigi/pull/1002) Implicit structural nodes ([@maxmarkus](https://github.com/maxmarkus))
+- [#1014](https://github.com/luigi-project/luigi/pull/1014) Disable context switcher drop down caret when there is only one option ([@pekura](https://github.com/pekura))
+- [#1008](https://github.com/luigi-project/luigi/pull/1008) Custom item renderer for options in context switcher ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#993](https://github.com/luigi-project/luigi/pull/993) React setup ([@ndricimrr](https://github.com/ndricimrr))
+- [#994](https://github.com/luigi-project/luigi/pull/994) Handle init in Luigi client without init handshake ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#1028](https://github.com/luigi-project/luigi/pull/1028) Add navigation functionality to core api ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#1017](https://github.com/SAP/luigi/pull/1017) Improve root nav caching ([@maxmarkus](https://github.com/maxmarkus))
-- [#1027](https://github.com/SAP/luigi/pull/1027) Add nonce param for OAuth2 and parameters to userInfoFn ([@maxmarkus](https://github.com/maxmarkus))
+- [#1017](https://github.com/luigi-project/luigi/pull/1017) Improve root nav caching ([@maxmarkus](https://github.com/maxmarkus))
+- [#1027](https://github.com/luigi-project/luigi/pull/1027) Add nonce param for OAuth2 and parameters to userInfoFn ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#1023](https://github.com/SAP/luigi/pull/1023) Document anonymous access ([@maxmarkus](https://github.com/maxmarkus))
+- [#1023](https://github.com/luigi-project/luigi/pull/1023) Document anonymous access ([@maxmarkus](https://github.com/maxmarkus))
 
 ## [v0.7.2](2019-11-29)
 
 #### :rocket: Added
 
-- [#970](https://github.com/SAP/luigi/pull/970) Third party cookie check ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#941](https://github.com/SAP/luigi/pull/941) Strip down angular example app ([@pekura](https://github.com/pekura))
-- [#901](https://github.com/SAP/luigi/pull/901) Inactive lifecycle hook ([@maxmarkus](https://github.com/maxmarkus))
-- [#923](https://github.com/SAP/luigi/pull/923) Refactor authentication ([@maxmarkus](https://github.com/maxmarkus))
-- [#925](https://github.com/SAP/luigi/pull/925) Provide possibility to add alt attribute to the <img> tag ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#926](https://github.com/SAP/luigi/pull/926) Update vue example app ([@pekura](https://github.com/pekura))
+- [#970](https://github.com/luigi-project/luigi/pull/970) Third party cookie check ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#941](https://github.com/luigi-project/luigi/pull/941) Strip down angular example app ([@pekura](https://github.com/pekura))
+- [#901](https://github.com/luigi-project/luigi/pull/901) Inactive lifecycle hook ([@maxmarkus](https://github.com/maxmarkus))
+- [#923](https://github.com/luigi-project/luigi/pull/923) Refactor authentication ([@maxmarkus](https://github.com/maxmarkus))
+- [#925](https://github.com/luigi-project/luigi/pull/925) Provide possibility to add alt attribute to the <img> tag ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#926](https://github.com/luigi-project/luigi/pull/926) Update vue example app ([@pekura](https://github.com/pekura))
 
 #### :bug: Fixed
 
-- [#992](https://github.com/SAP/luigi/pull/992) Edge browser back issue fixed ([@maxmarkus](https://github.com/maxmarkus))
-- [#979](https://github.com/SAP/luigi/pull/979) Invalid initial root navigation node bug fix ([@maxmarkus](https://github.com/maxmarkus))
-- [#937](https://github.com/SAP/luigi/pull/937) Example app switcher backdrop bug fix ([@maxmarkus](https://github.com/maxmarkus))
+- [#992](https://github.com/luigi-project/luigi/pull/992) Edge browser back issue fixed ([@maxmarkus](https://github.com/maxmarkus))
+- [#979](https://github.com/luigi-project/luigi/pull/979) Invalid initial root navigation node bug fix ([@maxmarkus](https://github.com/maxmarkus))
+- [#937](https://github.com/luigi-project/luigi/pull/937) Example app switcher backdrop bug fix ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#982](https://github.com/SAP/luigi/pull/982) FAQ page in documentation ([@maxmarkus](https://github.com/maxmarkus))
-- [#969](https://github.com/SAP/luigi/pull/969) Luigi architecture page ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#957](https://github.com/SAP/luigi/pull/957) Luigi client installation document ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#907](https://github.com/SAP/luigi/pull/907) Categories for documentation ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#847](https://github.com/SAP/luigi/pull/847) Improve navigation parameters reference ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#982](https://github.com/luigi-project/luigi/pull/982) FAQ page in documentation ([@maxmarkus](https://github.com/maxmarkus))
+- [#969](https://github.com/luigi-project/luigi/pull/969) Luigi architecture page ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#957](https://github.com/luigi-project/luigi/pull/957) Luigi client installation document ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#907](https://github.com/luigi-project/luigi/pull/907) Categories for documentation ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#847](https://github.com/luigi-project/luigi/pull/847) Improve navigation parameters reference ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.7.1](2019-10-25)
 
 #### :rocket: Added
 
-- [#920](https://github.com/SAP/luigi/pull/920) Invalid auth provider error handling ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#920](https://github.com/luigi-project/luigi/pull/920) Invalid auth provider error handling ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#931](https://github.com/SAP/luigi/pull/931) The goBack context is not delivered to preserved view ([@pekura](https://github.com/pekura))
-- [#916](https://github.com/SAP/luigi/pull/916) Backdrop not covering split-view micro frontend ([@pekura](https://github.com/pekura))
+- [#931](https://github.com/luigi-project/luigi/pull/931) The goBack context is not delivered to preserved view ([@pekura](https://github.com/pekura))
+- [#916](https://github.com/luigi-project/luigi/pull/916) Backdrop not covering split-view micro frontend ([@pekura](https://github.com/pekura))
 
 ## [v0.7.0](2019-10-22)
 
 #### :rocket: Added
 
-- [#843](https://github.com/SAP/luigi/pull/843) Svelte 3 migration ([@pekura](https://github.com/pekura))
-- [#871](https://github.com/SAP/luigi/pull/871) Tab-style navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#900](https://github.com/SAP/luigi/pull/900) TabNav component refactoring ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#894](https://github.com/SAP/luigi/pull/894) Add hook at micro frontend container creation ([@pekura](https://github.com/pekura))
+- [#843](https://github.com/luigi-project/luigi/pull/843) Svelte 3 migration ([@pekura](https://github.com/pekura))
+- [#871](https://github.com/luigi-project/luigi/pull/871) Tab-style navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#900](https://github.com/luigi-project/luigi/pull/900) TabNav component refactoring ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#894](https://github.com/luigi-project/luigi/pull/894) Add hook at micro frontend container creation ([@pekura](https://github.com/pekura))
 
 #### :rocket: Fixed
 
-- [#917](https://github.com/SAP/luigi/pull/917) Split view container doesn't hide ([@pekura](https://github.com/pekura))
+- [#917](https://github.com/luigi-project/luigi/pull/917) Split view container doesn't hide ([@pekura](https://github.com/pekura))
 
 #### :memo: Documentation
 
-- [#898](https://github.com/SAP/luigi/pull/898) Added links to getting started guide ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#869](https://github.com/SAP/luigi/pull/869) Fixed api links ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#881](https://github.com/SAP/luigi/pull/881) Add and describe "allowRules" in the general settings ([@zarkosimic](https://github.com/zarkosimic))
-- [#867](https://github.com/SAP/luigi/pull/867) Improve Luigi readme ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#866](https://github.com/SAP/luigi/pull/866) Improve authorization configuration ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#836](https://github.com/SAP/luigi/pull/836) Create getting started guide ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#898](https://github.com/luigi-project/luigi/pull/898) Added links to getting started guide ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#869](https://github.com/luigi-project/luigi/pull/869) Fixed api links ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#881](https://github.com/luigi-project/luigi/pull/881) Add and describe "allowRules" in the general settings ([@zarkosimic](https://github.com/zarkosimic))
+- [#867](https://github.com/luigi-project/luigi/pull/867) Improve Luigi readme ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#866](https://github.com/luigi-project/luigi/pull/866) Improve authorization configuration ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#836](https://github.com/luigi-project/luigi/pull/836) Create getting started guide ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.6.6](2019-10-09)
 
 #### :rocket: Fixed
 
-- [#876](https://github.com/SAP/luigi/pull/876) nodeAccessibilityResolver sometimes not re-applied on context switch ([@pekura](https://github.com/pekura))
+- [#876](https://github.com/luigi-project/luigi/pull/876) nodeAccessibilityResolver sometimes not re-applied on context switch ([@pekura](https://github.com/pekura))
 
 ## [v0.6.5](2019-10-07)
 
 #### :rocket: Added
 
-- [#832](https://github.com/SAP/luigi/pull/832) Set userinfo without auth, new navigation.profile.staticUserInfoFn ([@maxmarkus](https://github.com/maxmarkus))
-- [#845](https://github.com/SAP/luigi/pull/845) Extend iframe with "allow" attribute ([@zarkosimic](https://github.com/zarkosimic))
-- [#840](https://github.com/SAP/luigi/pull/840) Move show alert and show confirmation modal to new core api ux section ([@zarkosimic](https://github.com/zarkosimic))
-- [#846](https://github.com/SAP/luigi/pull/846) default icon for left nav item when it's collapsed ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#830](https://github.com/SAP/luigi/pull/830) SEO optimisation ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#832](https://github.com/luigi-project/luigi/pull/832) Set userinfo without auth, new navigation.profile.staticUserInfoFn ([@maxmarkus](https://github.com/maxmarkus))
+- [#845](https://github.com/luigi-project/luigi/pull/845) Extend iframe with "allow" attribute ([@zarkosimic](https://github.com/zarkosimic))
+- [#840](https://github.com/luigi-project/luigi/pull/840) Move show alert and show confirmation modal to new core api ux section ([@zarkosimic](https://github.com/zarkosimic))
+- [#846](https://github.com/luigi-project/luigi/pull/846) default icon for left nav item when it's collapsed ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#830](https://github.com/luigi-project/luigi/pull/830) SEO optimisation ([@marynaKhromova](https://github.com/marynaKhromova))
 
 #### :bug: Fixed
 
-- [#834](https://github.com/SAP/luigi/pull/834) Vue app auth error ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#834](https://github.com/luigi-project/luigi/pull/834) Vue app auth error ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :memo: Documentation
 
-- [#864](https://github.com/SAP/luigi/pull/864) fixed links to Lerna ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#862](https://github.com/SAP/luigi/pull/862) Fiddle links in docs ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#857](https://github.com/SAP/luigi/pull/857) Clean up example links in docs ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#826](https://github.com/SAP/luigi/pull/826) Improve navigation-configuration.md ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
-- [#840](https://github.com/SAP/luigi/pull/840) Move show alert and show confirmation modal to new core api ux section ([@zarkosimic](https://github.com/zarkosimic))
-- [#813](https://github.com/SAP/luigi/pull/813) Improve Luigi docs readme file ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#864](https://github.com/luigi-project/luigi/pull/864) fixed links to Lerna ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#862](https://github.com/luigi-project/luigi/pull/862) Fiddle links in docs ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#857](https://github.com/luigi-project/luigi/pull/857) Clean up example links in docs ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#826](https://github.com/luigi-project/luigi/pull/826) Improve navigation-configuration.md ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#840](https://github.com/luigi-project/luigi/pull/840) Move show alert and show confirmation modal to new core api ux section ([@zarkosimic](https://github.com/zarkosimic))
+- [#813](https://github.com/luigi-project/luigi/pull/813) Improve Luigi docs readme file ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.6.4](2019-09-13)
 
 #### :rocket: Added
 
-- [#825](https://github.com/SAP/luigi/pull/825) Context switcher should (optionally) not shorten the navigation path on context change ([@pekura](https://github.com/pekura))
-- [#812](https://github.com/SAP/luigi/pull/812) custom logout action in profile section ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#787](https://github.com/SAP/luigi/pull/787) luigiAfterInit lifecycle hook + app loading indicator ([@maxmarkus](https://github.com/maxmarkus))
-- [#803](https://github.com/SAP/luigi/pull/803) Title dropdown feature for switching applications ([@pekura](https://github.com/pekura))
-- [#791](https://github.com/SAP/luigi/pull/791) user menu without authorization ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#825](https://github.com/luigi-project/luigi/pull/825) Context switcher should (optionally) not shorten the navigation path on context change ([@pekura](https://github.com/pekura))
+- [#812](https://github.com/luigi-project/luigi/pull/812) custom logout action in profile section ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#787](https://github.com/luigi-project/luigi/pull/787) luigiAfterInit lifecycle hook + app loading indicator ([@maxmarkus](https://github.com/maxmarkus))
+- [#803](https://github.com/luigi-project/luigi/pull/803) Title dropdown feature for switching applications ([@pekura](https://github.com/pekura))
+- [#791](https://github.com/luigi-project/luigi/pull/791) user menu without authorization ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#821](https://github.com/SAP/luigi/pull/821) Rework backdrop for luigi-app-root bootstrap mode ([@zarkosimic](https://github.com/zarkosimic))
+- [#821](https://github.com/luigi-project/luigi/pull/821) Rework backdrop for luigi-app-root bootstrap mode ([@zarkosimic](https://github.com/zarkosimic))
 
 ## [v0.6.3](2019-09-05)
 
 #### :rocket: Added
 
-- [#792](https://github.com/SAP/luigi/pull/792) Avoid Luigi not configured alert ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#790](https://github.com/SAP/luigi/pull/790) Replace UI tests attributes ([@zarkosimic](https://github.com/zarkosimic))
+- [#792](https://github.com/luigi-project/luigi/pull/792) Avoid Luigi not configured alert ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#790](https://github.com/luigi-project/luigi/pull/790) Replace UI tests attributes ([@zarkosimic](https://github.com/zarkosimic))
 
 #### :memo: Documentation
 
-- [#794](https://github.com/SAP/luigi/pull/794) Change spelling to "micro frontend" ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
+- [#794](https://github.com/luigi-project/luigi/pull/794) Change spelling to "micro frontend" ([@alexandra-simeonova](https://github.com/alexandra-simeonova))
 
 ## [v0.6.2](2019-08-29)
 
 #### :rocket: Added
 
-- [#746](https://github.com/SAP/luigi/pull/746) Custom events for core client communication ([@maxmarkus](https://github.com/maxmarkus))
-- [#756](https://github.com/SAP/luigi/pull/756) Add test attribute to navigation nodes ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#752](https://github.com/SAP/luigi/pull/752) Mechanism for partial Luigi config update ([@pekura](https://github.com/pekura))
-- [#745](https://github.com/SAP/luigi/pull/745) Extend iframe sandbox rules ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#746](https://github.com/luigi-project/luigi/pull/746) Custom events for core client communication ([@maxmarkus](https://github.com/maxmarkus))
+- [#756](https://github.com/luigi-project/luigi/pull/756) Add test attribute to navigation nodes ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#752](https://github.com/luigi-project/luigi/pull/752) Mechanism for partial Luigi config update ([@pekura](https://github.com/pekura))
+- [#745](https://github.com/luigi-project/luigi/pull/745) Extend iframe sandbox rules ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#760](https://github.com/SAP/luigi/pull/760) Prevent luigi.auth.tokenIssued infinite loop ([@maxmarkus](https://github.com/maxmarkus))
+- [#760](https://github.com/luigi-project/luigi/pull/760) Prevent luigi.auth.tokenIssued infinite loop ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#717](https://github.com/SAP/luigi/pull/717) Add documentation for responsive app setup ([@jesusreal](https://github.com/jesusreal))
+- [#717](https://github.com/luigi-project/luigi/pull/717) Add documentation for responsive app setup ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.6.1](2019-08-09)
 
 #### :rocket: Added
 
-- [#725](https://github.com/SAP/luigi/pull/725) I18n luigi internal texts and messages translatable ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#703](https://github.com/SAP/luigi/pull/703) Product Switcher documentation and configurable label and icon ([@maxmarkus](https://github.com/maxmarkus))
+- [#725](https://github.com/luigi-project/luigi/pull/725) I18n luigi internal texts and messages translatable ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#703](https://github.com/luigi-project/luigi/pull/703) Product Switcher documentation and configurable label and icon ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#741](https://github.com/SAP/luigi/pull/741) Dynamic node and link/external link nodes as siblings ([@pekura](https://github.com/pekura))
+- [#741](https://github.com/luigi-project/luigi/pull/741) Dynamic node and link/external link nodes as siblings ([@pekura](https://github.com/pekura))
 
 #### :memo: Documentation
 
-- [#697](https://github.com/SAP/luigi/pull/697) Callback documentation for LuigiClient.addInitListener ([@maxmarkus](https://github.com/maxmarkus))
-- [#703](https://github.com/SAP/luigi/pull/703) Product Switcher documentation and configurable label and icon ([@maxmarkus](https://github.com/maxmarkus))
+- [#697](https://github.com/luigi-project/luigi/pull/697) Callback documentation for LuigiClient.addInitListener ([@maxmarkus](https://github.com/maxmarkus))
+- [#703](https://github.com/luigi-project/luigi/pull/703) Product Switcher documentation and configurable label and icon ([@maxmarkus](https://github.com/maxmarkus))
 
 ## [v0.6.0](2019-08-02)
 
 #### :rocket: Added
 
-- [#705](https://github.com/SAP/luigi/pull/705) Core api for getting translation for a specified key for given locale ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#707](https://github.com/SAP/luigi/pull/707) Add luigi bootstrap dom element option ([@jesusreal](https://github.com/jesusreal))
-- [#694](https://github.com/SAP/luigi/pull/694) smooth scrolling on mobile devices ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#669](https://github.com/SAP/luigi/pull/669) product switcher header to fiori3 concept ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#678](https://github.com/SAP/luigi/pull/678) Client permissions available in the client ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#650](https://github.com/SAP/luigi/pull/650) Split View micro frontends ([@maxmarkus](https://github.com/maxmarkus))
-- [#664](https://github.com/SAP/luigi/pull/664) Accumulated badge counter for mobile ([@maxmarkus](https://github.com/maxmarkus))
+- [#705](https://github.com/luigi-project/luigi/pull/705) Core api for getting translation for a specified key for given locale ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#707](https://github.com/luigi-project/luigi/pull/707) Add luigi bootstrap dom element option ([@jesusreal](https://github.com/jesusreal))
+- [#694](https://github.com/luigi-project/luigi/pull/694) smooth scrolling on mobile devices ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#669](https://github.com/luigi-project/luigi/pull/669) product switcher header to fiori3 concept ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#678](https://github.com/luigi-project/luigi/pull/678) Client permissions available in the client ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#650](https://github.com/luigi-project/luigi/pull/650) Split View micro frontends ([@maxmarkus](https://github.com/maxmarkus))
+- [#664](https://github.com/luigi-project/luigi/pull/664) Accumulated badge counter for mobile ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#712](https://github.com/SAP/luigi/pull/712) Fix error on click on navigation node when node is active ([@jesusreal](https://github.com/jesusreal))
-- [#500](https://github.com/SAP/luigi/pull/500) Fix path routing ([@y-kkamil](https://github.com/y-kkamil))
-- [#665](https://github.com/SAP/luigi/pull/665) Fix custom idp provider login function check ([@maxmarkus](https://github.com/maxmarkus))
+- [#712](https://github.com/luigi-project/luigi/pull/712) Fix error on click on navigation node when node is active ([@jesusreal](https://github.com/jesusreal))
+- [#500](https://github.com/luigi-project/luigi/pull/500) Fix path routing ([@y-kkamil](https://github.com/y-kkamil))
+- [#665](https://github.com/luigi-project/luigi/pull/665) Fix custom idp provider login function check ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#690](https://github.com/SAP/luigi/pull/690) Open split view in collapsed state ([@maxmarkus](https://github.com/maxmarkus))
-- [#668](https://github.com/SAP/luigi/pull/668) Fix broken links in docu for auth providers ([@jesusreal](https://github.com/jesusreal))
+- [#690](https://github.com/luigi-project/luigi/pull/690) Open split view in collapsed state ([@maxmarkus](https://github.com/maxmarkus))
+- [#668](https://github.com/luigi-project/luigi/pull/668) Fix broken links in docu for auth providers ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.5.4](2019-07-29)
 
 #### :bug: Fixed
 
-- [#708](https://github.com/SAP/luigi/issues/708) Fix error on click on navigation node when node is active ([@jesusreal](https://github.com/jesusreal))
+- [#708](https://github.com/luigi-project/luigi/issues/708) Fix error on click on navigation node when node is active ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.5.3](2019-07-23)
 
 #### :rocket: Added
 
-- [#663](https://github.com/SAP/luigi/pull/663) Remove nav highlight for semiCollapsible collapsed category ([@maxmarkus](https://github.com/maxmarkus))
-- [#648](https://github.com/SAP/luigi/pull/648) Generic node actions ([@jesusreal](https://github.com/jesusreal))
-- [#651](https://github.com/SAP/luigi/pull/651) Post message target handling in Luigi Client ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#562](https://github.com/SAP/luigi/pull/562) Notification badge for counters ([@maxmarkus](https://github.com/maxmarkus))
-- [#640](https://github.com/SAP/luigi/pull/640) Remove external link indicator for shellbar header nodes ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#663](https://github.com/luigi-project/luigi/pull/663) Remove nav highlight for semiCollapsible collapsed category ([@maxmarkus](https://github.com/maxmarkus))
+- [#648](https://github.com/luigi-project/luigi/pull/648) Generic node actions ([@jesusreal](https://github.com/jesusreal))
+- [#651](https://github.com/luigi-project/luigi/pull/651) Post message target handling in Luigi Client ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#562](https://github.com/luigi-project/luigi/pull/562) Notification badge for counters ([@maxmarkus](https://github.com/maxmarkus))
+- [#640](https://github.com/luigi-project/luigi/pull/640) Remove external link indicator for shellbar header nodes ([@marynaKhromova](https://github.com/marynaKhromova))
 
 #### :memo: Documentation
 
-- [#638](https://github.com/SAP/luigi/pull/638) Security dev guidelines for MF ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#638](https://github.com/luigi-project/luigi/pull/638) Security dev guidelines for MF ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## [v0.5.2](2019-07-12)
 
 #### :rocket: Added
 
-- [#639](https://github.com/SAP/luigi/pull/639) Alias function for getEventData ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#639](https://github.com/luigi-project/luigi/pull/639) Alias function for getEventData ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#653](https://github.com/SAP/luigi/pull/653) Context switcher does not work when parentNodePath is root ([@pekura](https://github.com/pekura))
-- [#647](https://github.com/SAP/luigi/pull/647) Lodash vulnerability fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#653](https://github.com/luigi-project/luigi/pull/653) Context switcher does not work when parentNodePath is root ([@pekura](https://github.com/pekura))
+- [#647](https://github.com/luigi-project/luigi/pull/647) Lodash vulnerability fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## [v0.5.1](2019-07-09)
 
 #### :bug: Fixed
 
-- [#632](https://github.com/SAP/luigi/pull/632) Remove side navigation footer when no footer text and no semi-collapsible navigation ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#632](https://github.com/luigi-project/luigi/pull/632) Remove side navigation footer when no footer text and no semi-collapsible navigation ([@marynaKhromova](https://github.com/marynaKhromova))
 
 #### :memo: Documentation
 
-- [#623](https://github.com/SAP/luigi/pull/623) Node category documentation ([@maxmarkus](https://github.com/maxmarkus))
-- [#627](https://github.com/SAP/luigi/pull/627) Document view groups ([@jesusreal](https://github.com/jesusreal))
+- [#623](https://github.com/luigi-project/luigi/pull/623) Node category documentation ([@maxmarkus](https://github.com/maxmarkus))
+- [#627](https://github.com/luigi-project/luigi/pull/627) Document view groups ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.5.0](2019-07-04)
 
 #### :rocket: Added
 
-- [#626](https://github.com/SAP/luigi/pull/626) Open modal from navigation node ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#624](https://github.com/SAP/luigi/pull/624) Fiori 3 compliant left navigation collapse ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#610](https://github.com/SAP/luigi/pull/610) Improve default child mechanism ([@maxmarkus](https://github.com/maxmarkus))
-- [#618](https://github.com/SAP/luigi/pull/618) Dropdown functionality for top right navigation nodes ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#601](https://github.com/SAP/luigi/pull/601) Add ie11 support ([@jesusreal](https://github.com/jesusreal))
-- [#600](https://github.com/SAP/luigi/pull/600) View group preloading ([@pekura](https://github.com/pekura))
-- [#595](https://github.com/SAP/luigi/pull/595) Add goBack support for normal navigation ([@maxmarkus](https://github.com/maxmarkus))
-- [#596](https://github.com/SAP/luigi/pull/596) Add allow-modals to iframe sandbox options ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#626](https://github.com/luigi-project/luigi/pull/626) Open modal from navigation node ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#624](https://github.com/luigi-project/luigi/pull/624) Fiori 3 compliant left navigation collapse ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#610](https://github.com/luigi-project/luigi/pull/610) Improve default child mechanism ([@maxmarkus](https://github.com/maxmarkus))
+- [#618](https://github.com/luigi-project/luigi/pull/618) Dropdown functionality for top right navigation nodes ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#601](https://github.com/luigi-project/luigi/pull/601) Add ie11 support ([@jesusreal](https://github.com/jesusreal))
+- [#600](https://github.com/luigi-project/luigi/pull/600) View group preloading ([@pekura](https://github.com/pekura))
+- [#595](https://github.com/luigi-project/luigi/pull/595) Add goBack support for normal navigation ([@maxmarkus](https://github.com/maxmarkus))
+- [#596](https://github.com/luigi-project/luigi/pull/596) Add allow-modals to iframe sandbox options ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#613](https://github.com/SAP/luigi/pull/613) ContextSwitcher: Always reload if lazyLoadOption is enabled ([@maxmarkus](https://github.com/maxmarkus))
-- [#608](https://github.com/SAP/luigi/pull/608) Fix core package json merge error ([@jesusreal](https://github.com/jesusreal))
+- [#613](https://github.com/luigi-project/luigi/pull/613) ContextSwitcher: Always reload if lazyLoadOption is enabled ([@maxmarkus](https://github.com/maxmarkus))
+- [#608](https://github.com/luigi-project/luigi/pull/608) Fix core package json merge error ([@jesusreal](https://github.com/jesusreal))
 
 #### :memo: Documentation
 
-- [#621](https://github.com/SAP/luigi/pull/621) Update the general settings docu ([@bszwarc](https://github.com/bszwarc))
-- [#602](https://github.com/SAP/luigi/pull/602) Core API docu ([@maxmarkus](https://github.com/maxmarkus))
+- [#621](https://github.com/luigi-project/luigi/pull/621) Update the general settings docu ([@bszwarc](https://github.com/bszwarc))
+- [#602](https://github.com/luigi-project/luigi/pull/602) Core API docu ([@maxmarkus](https://github.com/maxmarkus))
 
 ## [v0.4.12](2019-06-24)
 
 #### :rocket: Added
 
-- [#585](https://github.com/SAP/luigi/pull/585) 577 close modals by esc-key ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#545](https://github.com/SAP/luigi/pull/545) On auth expire soon event ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#569](https://github.com/SAP/luigi/pull/569) Reduce luigi client and core bundle size ([@jesusreal](https://github.com/jesusreal))
-- [#552](https://github.com/SAP/luigi/pull/552) Improve control over luigi bootstrap process ([@pekura](https://github.com/pekura))
-- [#544](https://github.com/SAP/luigi/pull/544) Extend luigi core api by methods for getting important dom elements ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#501](https://github.com/SAP/luigi/pull/501) Luigi Authentication Events ([@maxmarkus](https://github.com/maxmarkus))
-- [#503](https://github.com/SAP/luigi/pull/503) Display info in bottom left corner ([@parostatkiem](https://github.com/parostatkiem))
-- [#520](https://github.com/SAP/luigi/pull/520) Cache and reuse viewgroups frame ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#514](https://github.com/SAP/luigi/pull/514) display picture in topnav for idp flow ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#504](https://github.com/SAP/luigi/pull/504) Add user pic to userinfo ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#498](https://github.com/SAP/luigi/pull/498) Update unit tests dependencies for luigi core ([@jesusreal](https://github.com/jesusreal))
-- [#493](https://github.com/SAP/luigi/pull/493) Make profile dropdown extensible ([@jesusreal](https://github.com/jesusreal))
-- [#480](https://github.com/SAP/luigi/pull/480) Alert improvements ([@parostatkiem](https://github.com/parostatkiem))
-- [#484](https://github.com/SAP/luigi/pull/484) Display userinfo ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#476](https://github.com/SAP/luigi/pull/476) remove unnecessary styles ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#585](https://github.com/luigi-project/luigi/pull/585) 577 close modals by esc-key ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#545](https://github.com/luigi-project/luigi/pull/545) On auth expire soon event ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#569](https://github.com/luigi-project/luigi/pull/569) Reduce luigi client and core bundle size ([@jesusreal](https://github.com/jesusreal))
+- [#552](https://github.com/luigi-project/luigi/pull/552) Improve control over luigi bootstrap process ([@pekura](https://github.com/pekura))
+- [#544](https://github.com/luigi-project/luigi/pull/544) Extend luigi core api by methods for getting important dom elements ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#501](https://github.com/luigi-project/luigi/pull/501) Luigi Authentication Events ([@maxmarkus](https://github.com/maxmarkus))
+- [#503](https://github.com/luigi-project/luigi/pull/503) Display info in bottom left corner ([@parostatkiem](https://github.com/parostatkiem))
+- [#520](https://github.com/luigi-project/luigi/pull/520) Cache and reuse viewgroups frame ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#514](https://github.com/luigi-project/luigi/pull/514) display picture in topnav for idp flow ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#504](https://github.com/luigi-project/luigi/pull/504) Add user pic to userinfo ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#498](https://github.com/luigi-project/luigi/pull/498) Update unit tests dependencies for luigi core ([@jesusreal](https://github.com/jesusreal))
+- [#493](https://github.com/luigi-project/luigi/pull/493) Make profile dropdown extensible ([@jesusreal](https://github.com/jesusreal))
+- [#480](https://github.com/luigi-project/luigi/pull/480) Alert improvements ([@parostatkiem](https://github.com/parostatkiem))
+- [#484](https://github.com/luigi-project/luigi/pull/484) Display userinfo ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#476](https://github.com/luigi-project/luigi/pull/476) remove unnecessary styles ([@marynaKhromova](https://github.com/marynaKhromova))
 
 #### :bug: Fixed
 
-- [#599](https://github.com/SAP/luigi/pull/599) diff vulnerability fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#580](https://github.com/SAP/luigi/pull/580) axios vulnerability fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#575](https://github.com/SAP/luigi/pull/575) Node refresh bug on hash routing ([@jesusreal](https://github.com/jesusreal))
-- [#566](https://github.com/SAP/luigi/pull/566) Improve e2e testrunner script ([@maxmarkus](https://github.com/maxmarkus))
-- [#561](https://github.com/SAP/luigi/pull/561) Fix e2e install ([@maxmarkus](https://github.com/maxmarkus))
-- [#558](https://github.com/SAP/luigi/pull/558) Fix bug by overwriting description only when present ([@jesusreal](https://github.com/jesusreal))
-- [#526](https://github.com/SAP/luigi/pull/526) Bug in left navigation ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#528](https://github.com/SAP/luigi/pull/528) Error message for invalid auth provider ([@maxmarkus](https://github.com/maxmarkus))
-- [#530](https://github.com/SAP/luigi/pull/530) Fix dev server reload issue ([@maxmarkus](https://github.com/maxmarkus))
-- [#523](https://github.com/SAP/luigi/pull/523) 485 fix headerjs error ([@maxmarkus](https://github.com/maxmarkus))
-- [#482](https://github.com/SAP/luigi/pull/482) fix linter errors ([@maxmarkus](https://github.com/maxmarkus))
+- [#599](https://github.com/luigi-project/luigi/pull/599) diff vulnerability fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#580](https://github.com/luigi-project/luigi/pull/580) axios vulnerability fix ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#575](https://github.com/luigi-project/luigi/pull/575) Node refresh bug on hash routing ([@jesusreal](https://github.com/jesusreal))
+- [#566](https://github.com/luigi-project/luigi/pull/566) Improve e2e testrunner script ([@maxmarkus](https://github.com/maxmarkus))
+- [#561](https://github.com/luigi-project/luigi/pull/561) Fix e2e install ([@maxmarkus](https://github.com/maxmarkus))
+- [#558](https://github.com/luigi-project/luigi/pull/558) Fix bug by overwriting description only when present ([@jesusreal](https://github.com/jesusreal))
+- [#526](https://github.com/luigi-project/luigi/pull/526) Bug in left navigation ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#528](https://github.com/luigi-project/luigi/pull/528) Error message for invalid auth provider ([@maxmarkus](https://github.com/maxmarkus))
+- [#530](https://github.com/luigi-project/luigi/pull/530) Fix dev server reload issue ([@maxmarkus](https://github.com/maxmarkus))
+- [#523](https://github.com/luigi-project/luigi/pull/523) 485 fix headerjs error ([@maxmarkus](https://github.com/maxmarkus))
+- [#482](https://github.com/luigi-project/luigi/pull/482) fix linter errors ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#546](https://github.com/SAP/luigi/pull/546) Modernize luigi client ([@maxmarkus](https://github.com/maxmarkus))
-- [#544](https://github.com/SAP/luigi/pull/544) Extend luigi core api by methods for getting important dom elements ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#542](https://github.com/SAP/luigi/pull/542) Documented luigi.auth.tokenIssued event ([@maxmarkus](https://github.com/maxmarkus))
-- [#531](https://github.com/SAP/luigi/pull/531) Cleanup codeowners and contributing files ([@jesusreal](https://github.com/jesusreal))
+- [#546](https://github.com/luigi-project/luigi/pull/546) Modernize luigi client ([@maxmarkus](https://github.com/maxmarkus))
+- [#544](https://github.com/luigi-project/luigi/pull/544) Extend luigi core api by methods for getting important dom elements ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#542](https://github.com/luigi-project/luigi/pull/542) Documented luigi.auth.tokenIssued event ([@maxmarkus](https://github.com/maxmarkus))
+- [#531](https://github.com/luigi-project/luigi/pull/531) Cleanup codeowners and contributing files ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.4.11](2019-04-12)
 
 #### :rocket: Added
 
-- [#468](https://github.com/SAP/luigi/pull/468) Check origin of postMessages ([@dariadomagala](https://github.com/dariadomagala))
-- [#460](https://github.com/SAP/luigi/pull/460) Modal mfs e2e tests ([@parostatkiem](https://github.com/parostatkiem))
-- [#451](https://github.com/SAP/luigi/pull/451) Prevent unlogged rendering ([@parostatkiem](https://github.com/parostatkiem))
-- [#463](https://github.com/SAP/luigi/pull/463) Add simple collapsible navigation option ([@hardl](https://github.com/hardl))
-- [#459](https://github.com/SAP/luigi/pull/459) Display labels in mobile top header menu, vertical alignment for labels ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#446](https://github.com/SAP/luigi/pull/446) Modal mfs ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#438](https://github.com/SAP/luigi/pull/438) Improve login error behavior ([@maxmarkus](https://github.com/maxmarkus))
-- [#437](https://github.com/SAP/luigi/pull/437) Optimize luigi.css size ([@marynaKhromova](https://github.com/marynaKhromova))
-- [#424](https://github.com/SAP/luigi/pull/424) Product switcher on mobile ([@parostatkiem](https://github.com/parostatkiem))
-- [#435](https://github.com/SAP/luigi/pull/435) Fix alert message hidden under content window ([@y-kkamil](https://github.com/y-kkamil))
-- [#425](https://github.com/SAP/luigi/pull/425) Add ts declaration file ([@y-kkamil](https://github.com/y-kkamil))
-- [#423](https://github.com/SAP/luigi/pull/423) Duplicated logos and app switcher markup ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#468](https://github.com/luigi-project/luigi/pull/468) Check origin of postMessages ([@dariadomagala](https://github.com/dariadomagala))
+- [#460](https://github.com/luigi-project/luigi/pull/460) Modal mfs e2e tests ([@parostatkiem](https://github.com/parostatkiem))
+- [#451](https://github.com/luigi-project/luigi/pull/451) Prevent unlogged rendering ([@parostatkiem](https://github.com/parostatkiem))
+- [#463](https://github.com/luigi-project/luigi/pull/463) Add simple collapsible navigation option ([@hardl](https://github.com/hardl))
+- [#459](https://github.com/luigi-project/luigi/pull/459) Display labels in mobile top header menu, vertical alignment for labels ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#446](https://github.com/luigi-project/luigi/pull/446) Modal mfs ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#438](https://github.com/luigi-project/luigi/pull/438) Improve login error behavior ([@maxmarkus](https://github.com/maxmarkus))
+- [#437](https://github.com/luigi-project/luigi/pull/437) Optimize luigi.css size ([@marynaKhromova](https://github.com/marynaKhromova))
+- [#424](https://github.com/luigi-project/luigi/pull/424) Product switcher on mobile ([@parostatkiem](https://github.com/parostatkiem))
+- [#435](https://github.com/luigi-project/luigi/pull/435) Fix alert message hidden under content window ([@y-kkamil](https://github.com/y-kkamil))
+- [#425](https://github.com/luigi-project/luigi/pull/425) Add ts declaration file ([@y-kkamil](https://github.com/y-kkamil))
+- [#423](https://github.com/luigi-project/luigi/pull/423) Duplicated logos and app switcher markup ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#461](https://github.com/SAP/luigi/pull/461) Prevent unescaped characters in the Alert component ([@y-kkamil](https://github.com/y-kkamil))
-- [#466](https://github.com/SAP/luigi/pull/466) Deactivate Typescript Declaration file for Luigi Client ([@jesusreal](https://github.com/jesusreal))
-- [#448](https://github.com/SAP/luigi/pull/448) Escape some html characters for alert component ([@y-kkamil](https://github.com/y-kkamil))
-- [#429](https://github.com/SAP/luigi/pull/429) Luigi Client package should not contain src folder ([@jesusreal](https://github.com/jesusreal))
-- [#427](https://github.com/SAP/luigi/pull/427) Fix transparent background in alerts ([@dariadomagala](https://github.com/dariadomagala))
+- [#461](https://github.com/luigi-project/luigi/pull/461) Prevent unescaped characters in the Alert component ([@y-kkamil](https://github.com/y-kkamil))
+- [#466](https://github.com/luigi-project/luigi/pull/466) Deactivate Typescript Declaration file for Luigi Client ([@jesusreal](https://github.com/jesusreal))
+- [#448](https://github.com/luigi-project/luigi/pull/448) Escape some html characters for alert component ([@y-kkamil](https://github.com/y-kkamil))
+- [#429](https://github.com/luigi-project/luigi/pull/429) Luigi Client package should not contain src folder ([@jesusreal](https://github.com/jesusreal))
+- [#427](https://github.com/luigi-project/luigi/pull/427) Fix transparent background in alerts ([@dariadomagala](https://github.com/dariadomagala))
 
 #### :memo: Documentation
 
-- [#454](https://github.com/SAP/luigi/pull/454) Documentation for modal micro frontends ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#442](https://github.com/SAP/luigi/pull/442) Remove Creative Commons license from the docs folder ([@klaudiagrz](https://github.com/klaudiagrz))
-- [#419](https://github.com/SAP/luigi/pull/419) Change the codeowners file ([@mmitoraj](https://github.com/mmitoraj))
+- [#454](https://github.com/luigi-project/luigi/pull/454) Documentation for modal micro frontends ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#442](https://github.com/luigi-project/luigi/pull/442) Remove Creative Commons license from the docs folder ([@klaudiagrz](https://github.com/klaudiagrz))
+- [#419](https://github.com/luigi-project/luigi/pull/419) Change the codeowners file ([@mmitoraj](https://github.com/mmitoraj))
 
 ## [v0.4.10](2019-03-08)
 
 #### :bug: Fixed
 
-- [#417](https://github.com/SAP/luigi/pull/417) Fix node refresh ([@hardl](https://github.com/hardl))
+- [#417](https://github.com/luigi-project/luigi/pull/417) Fix node refresh ([@hardl](https://github.com/hardl))
 
 ## [v0.4.9](2019-03-07)
 
 #### :bug: Fixed
 
-- [#412](https://github.com/SAP/luigi/pull/412) Focus improvements ([@hardl](https://github.com/hardl))
-- [#409](https://github.com/SAP/luigi/pull/409) Fix double-click selection issue ([@hardl](https://github.com/hardl))
-- [#411](https://github.com/SAP/luigi/pull/411) Wrap alert in an invisible overlay ([@parostatkiem](https://github.com/parostatkiem))
+- [#412](https://github.com/luigi-project/luigi/pull/412) Focus improvements ([@hardl](https://github.com/hardl))
+- [#409](https://github.com/luigi-project/luigi/pull/409) Fix double-click selection issue ([@hardl](https://github.com/hardl))
+- [#411](https://github.com/luigi-project/luigi/pull/411) Wrap alert in an invisible overlay ([@parostatkiem](https://github.com/parostatkiem))
 
 ## v0.4.8 (2019-02-20)
 
 #### :bug: Fixed
 
-- [#403](https://github.com/SAP/luigi/pull/403) fix generic alert bug ([@JohannesDoberer](https://github.com/JohannesDoberer))
-- [#333](https://github.com/SAP/luigi/pull/333) Fix errors when building luigi angular sample application ([@kwiatekus](https://github.com/kwiatekus))
+- [#403](https://github.com/luigi-project/luigi/pull/403) fix generic alert bug ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#333](https://github.com/luigi-project/luigi/pull/333) Fix errors when building luigi angular sample application ([@kwiatekus](https://github.com/kwiatekus))
 
 ## v0.4.7 (2019-02-08)
 
 #### :rocket: Added
 
-- [#395](https://github.com/SAP/luigi/pull/395) Add generic alert ([@jesusreal](https://github.com/jesusreal))
+- [#395](https://github.com/luigi-project/luigi/pull/395) Add generic alert ([@jesusreal](https://github.com/jesusreal))
 
 #### :bug: Fixed
 
-- [#394](https://github.com/SAP/luigi/pull/394) fix application setup issues ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#394](https://github.com/luigi-project/luigi/pull/394) fix application setup issues ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 ## v0.4.6 (2019-02-07)
 
 #### :rocket: Added
 
-- [#390](https://github.com/SAP/luigi/pull/390) Implement test coverage feature ([@parostatkiem](https://github.com/parostatkiem))
-- [#389](https://github.com/SAP/luigi/pull/389) Add generic confirmation modal ([@jesusreal](https://github.com/jesusreal))
-- [#385](https://github.com/SAP/luigi/pull/385) Reload micro frontend when clicking on selected node ([@maxmarkus](https://github.com/maxmarkus))
-- [#371](https://github.com/SAP/luigi/pull/371) add product switcher to navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
+- [#390](https://github.com/luigi-project/luigi/pull/390) Implement test coverage feature ([@parostatkiem](https://github.com/parostatkiem))
+- [#389](https://github.com/luigi-project/luigi/pull/389) Add generic confirmation modal ([@jesusreal](https://github.com/jesusreal))
+- [#385](https://github.com/luigi-project/luigi/pull/385) Reload micro frontend when clicking on selected node ([@maxmarkus](https://github.com/maxmarkus))
+- [#371](https://github.com/luigi-project/luigi/pull/371) add product switcher to navigation ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-- [#392](https://github.com/SAP/luigi/pull/392) Reload same node fails if no iframe exists ([@maxmarkus](https://github.com/maxmarkus))
-- [#380](https://github.com/SAP/luigi/pull/380) Fix default child and 404 error mechanism bug ([@dariadomagala](https://github.com/dariadomagala))
+- [#392](https://github.com/luigi-project/luigi/pull/392) Reload same node fails if no iframe exists ([@maxmarkus](https://github.com/maxmarkus))
+- [#380](https://github.com/luigi-project/luigi/pull/380) Fix default child and 404 error mechanism bug ([@dariadomagala](https://github.com/dariadomagala))
 
 ## [v0.4.5](2019-01-23)
 
 #### :rocket: Added
 
-- [#313](https://github.com/SAP/luigi/pull/313) Luigi config meets es6 ([@parostatkiem](https://github.com/parostatkiem))
-- [#325](https://github.com/SAP/luigi/pull/325) Webpack for LuigiClient ([@parostatkiem](https://github.com/parostatkiem))
-- [#321](https://github.com/SAP/luigi/pull/321) Dynamic nodes prevent navigation tree mutation ([@maxmarkus](https://github.com/maxmarkus))
-- [#310](https://github.com/SAP/luigi/pull/310) Improve 404 handling ([@parostatkiem](https://github.com/parostatkiem))
-- [#315](https://github.com/SAP/luigi/pull/315) Add isolate all views setting ([@dariadomagala](https://github.com/dariadomagala))
-- [#339](https://github.com/SAP/luigi/pull/339) Increase oidc client loading timeout ([@kwiatekus](https://github.com/kwiatekus))
+- [#313](https://github.com/luigi-project/luigi/pull/313) Luigi config meets es6 ([@parostatkiem](https://github.com/parostatkiem))
+- [#325](https://github.com/luigi-project/luigi/pull/325) Webpack for LuigiClient ([@parostatkiem](https://github.com/parostatkiem))
+- [#321](https://github.com/luigi-project/luigi/pull/321) Dynamic nodes prevent navigation tree mutation ([@maxmarkus](https://github.com/maxmarkus))
+- [#310](https://github.com/luigi-project/luigi/pull/310) Improve 404 handling ([@parostatkiem](https://github.com/parostatkiem))
+- [#315](https://github.com/luigi-project/luigi/pull/315) Add isolate all views setting ([@dariadomagala](https://github.com/dariadomagala))
+- [#339](https://github.com/luigi-project/luigi/pull/339) Increase oidc client loading timeout ([@kwiatekus](https://github.com/kwiatekus))
 
 #### :bug: Fixed
 
-- [#377](https://github.com/SAP/luigi/pull/377) Fix iframe top position ([@jesusreal](https://github.com/jesusreal))
-- [#378](https://github.com/SAP/luigi/pull/378) Fix frame reload on 404 ([@dariadomagala](https://github.com/dariadomagala))
-- [#368](https://github.com/SAP/luigi/pull/368) Dynamic path params not passed to children providers - fix ([@pekura](https://github.com/pekura))
-- [#362](https://github.com/SAP/luigi/pull/362) Relative navigation from client does not work with dynamic nodes ([@pekura](https://github.com/pekura))
-- [#349](https://github.com/SAP/luigi/pull/349) Fix preserve views node params ([@dariadomagala](https://github.com/dariadomagala))
-- [#361](https://github.com/SAP/luigi/pull/361) Empty navigation category should not be shown ([@pekura](https://github.com/pekura))
-- [#352](https://github.com/SAP/luigi/pull/352) Fix babel polyfill error ([@parostatkiem](https://github.com/parostatkiem))
-- [#342](https://github.com/SAP/luigi/pull/342) Ignore path params in context switcher label ([@parostatkiem](https://github.com/parostatkiem))
+- [#377](https://github.com/luigi-project/luigi/pull/377) Fix iframe top position ([@jesusreal](https://github.com/jesusreal))
+- [#378](https://github.com/luigi-project/luigi/pull/378) Fix frame reload on 404 ([@dariadomagala](https://github.com/dariadomagala))
+- [#368](https://github.com/luigi-project/luigi/pull/368) Dynamic path params not passed to children providers - fix ([@pekura](https://github.com/pekura))
+- [#362](https://github.com/luigi-project/luigi/pull/362) Relative navigation from client does not work with dynamic nodes ([@pekura](https://github.com/pekura))
+- [#349](https://github.com/luigi-project/luigi/pull/349) Fix preserve views node params ([@dariadomagala](https://github.com/dariadomagala))
+- [#361](https://github.com/luigi-project/luigi/pull/361) Empty navigation category should not be shown ([@pekura](https://github.com/pekura))
+- [#352](https://github.com/luigi-project/luigi/pull/352) Fix babel polyfill error ([@parostatkiem](https://github.com/parostatkiem))
+- [#342](https://github.com/luigi-project/luigi/pull/342) Ignore path params in context switcher label ([@parostatkiem](https://github.com/parostatkiem))
 
 #### :memo: Documentation
 
-- [#365](https://github.com/SAP/luigi/pull/365) Split documentation for navigation config ([@bszwarc](https://github.com/bszwarc))
-- [#343](https://github.com/SAP/luigi/pull/343) Add docs and examples for anonymous content ([@dariadomagala](https://github.com/dariadomagala))
-- [#313](https://github.com/SAP/luigi/pull/313) Luigi config meets es6 ([@parostatkiem](https://github.com/parostatkiem))
-- [#325](https://github.com/SAP/luigi/pull/325) Webpack for LuigiClient ([@parostatkiem](https://github.com/parostatkiem))
-- [#310](https://github.com/SAP/luigi/pull/310) Improve 404 handling ([@parostatkiem](https://github.com/parostatkiem))
-- [#315](https://github.com/SAP/luigi/pull/315) Add isolate all views setting ([@dariadomagala](https://github.com/dariadomagala))
-- [#344](https://github.com/SAP/luigi/pull/344) Fix formatting issues and add missing info ([@bszwarc](https://github.com/bszwarc))
+- [#365](https://github.com/luigi-project/luigi/pull/365) Split documentation for navigation config ([@bszwarc](https://github.com/bszwarc))
+- [#343](https://github.com/luigi-project/luigi/pull/343) Add docs and examples for anonymous content ([@dariadomagala](https://github.com/dariadomagala))
+- [#313](https://github.com/luigi-project/luigi/pull/313) Luigi config meets es6 ([@parostatkiem](https://github.com/parostatkiem))
+- [#325](https://github.com/luigi-project/luigi/pull/325) Webpack for LuigiClient ([@parostatkiem](https://github.com/parostatkiem))
+- [#310](https://github.com/luigi-project/luigi/pull/310) Improve 404 handling ([@parostatkiem](https://github.com/parostatkiem))
+- [#315](https://github.com/luigi-project/luigi/pull/315) Add isolate all views setting ([@dariadomagala](https://github.com/dariadomagala))
+- [#344](https://github.com/luigi-project/luigi/pull/344) Fix formatting issues and add missing info ([@bszwarc](https://github.com/bszwarc))
 
 ## [v0.4.4](2019-01-10)
 
 #### :rocket: Added
 
-- [#319](https://github.com/SAP/luigi/pull/319) Implement anonymous content feature ([@hardl](https://github.com/hardl))
-- [#306](https://github.com/SAP/luigi/pull/306) Icons in navigation nodes ([@parostatkiem](https://github.com/parostatkiem))
+- [#319](https://github.com/luigi-project/luigi/pull/319) Implement anonymous content feature ([@hardl](https://github.com/hardl))
+- [#306](https://github.com/luigi-project/luigi/pull/306) Icons in navigation nodes ([@parostatkiem](https://github.com/parostatkiem))
 
 #### :bug: Fixed
 
-- [#331](https://github.com/SAP/luigi/pull/331) Fix defaultChildNode mechanism for root path ([@jesusreal](https://github.com/jesusreal))
-- [#317](https://github.com/SAP/luigi/pull/317) Improve defaultChildNode ([@parostatkiem](https://github.com/parostatkiem))
+- [#331](https://github.com/luigi-project/luigi/pull/331) Fix defaultChildNode mechanism for root path ([@jesusreal](https://github.com/jesusreal))
+- [#317](https://github.com/luigi-project/luigi/pull/317) Improve defaultChildNode ([@parostatkiem](https://github.com/parostatkiem))
 
 #### :memo: Documentation
 
-- [#306](https://github.com/SAP/luigi/pull/306) Icons in navigation nodes ([@parostatkiem](https://github.com/parostatkiem))
+- [#306](https://github.com/luigi-project/luigi/pull/306) Icons in navigation nodes ([@parostatkiem](https://github.com/parostatkiem))
 
 ## [v0.4.3] - 2019-01-07
 
 #### :bug: Fixed
 
-- [#318](https://github.com/SAP/luigi/pull/318) Increase timeout and improve error handling for loading oidc client library ([@kwiatekus](https://github.com/kwiatekus))
-- [#312](https://github.com/SAP/luigi/pull/312) Fix node params for path routing ([@dariadomagala](https://github.com/dariadomagala))
+- [#318](https://github.com/luigi-project/luigi/pull/318) Increase timeout and improve error handling for loading oidc client library ([@kwiatekus](https://github.com/kwiatekus))
+- [#312](https://github.com/luigi-project/luigi/pull/312) Fix node params for path routing ([@dariadomagala](https://github.com/dariadomagala))
 
 ## [v0.4.1] - 2018-12-27
 
 #### :rocket: Added
 
-- [#252](https://github.com/SAP/luigi/pull/252) Unsaved changes modal ([@parostatkiem](https://github.com/parostatkiem))
-- [#288](https://github.com/SAP/luigi/pull/288) Add possibility to use pathRouting with angular-cli ([@maxmarkus](https://github.com/maxmarkus))
+- [#252](https://github.com/luigi-project/luigi/pull/252) Unsaved changes modal ([@parostatkiem](https://github.com/parostatkiem))
+- [#288](https://github.com/luigi-project/luigi/pull/288) Add possibility to use pathRouting with angular-cli ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#307](https://github.com/SAP/luigi/pull/307) Fix error with parsed data ([@dariadomagala](https://github.com/dariadomagala))
-- [#301](https://github.com/SAP/luigi/pull/301) Fix dropdowns behavior on click events ([@dariadomagala](https://github.com/dariadomagala))
-- [#305](https://github.com/SAP/luigi/pull/305) When adding a listener via Luigi Client API, call only the listener being added ([@jesusreal](https://github.com/jesusreal))
-- [#299](https://github.com/SAP/luigi/pull/299) It is not possible to have a root node with empty path segment and a view ([@pekura](https://github.com/pekura))
-- [#283](https://github.com/SAP/luigi/pull/283) Default child node mechanism breaks if path ends with a slash ([@pekura](https://github.com/pekura))
+- [#307](https://github.com/luigi-project/luigi/pull/307) Fix error with parsed data ([@dariadomagala](https://github.com/dariadomagala))
+- [#301](https://github.com/luigi-project/luigi/pull/301) Fix dropdowns behavior on click events ([@dariadomagala](https://github.com/dariadomagala))
+- [#305](https://github.com/luigi-project/luigi/pull/305) When adding a listener via Luigi Client API, call only the listener being added ([@jesusreal](https://github.com/jesusreal))
+- [#299](https://github.com/luigi-project/luigi/pull/299) It is not possible to have a root node with empty path segment and a view ([@pekura](https://github.com/pekura))
+- [#283](https://github.com/luigi-project/luigi/pull/283) Default child node mechanism breaks if path ends with a slash ([@pekura](https://github.com/pekura))
 
 #### :memo: Documentation
 
-- [#277](https://github.com/SAP/luigi/pull/277) Improve Luigi readme files ([@bszwarc](https://github.com/bszwarc))
-- [#282](https://github.com/SAP/luigi/pull/282) Add short README.md file about Luigi Core ([@bszwarc](https://github.com/bszwarc))
+- [#277](https://github.com/luigi-project/luigi/pull/277) Improve Luigi readme files ([@bszwarc](https://github.com/bszwarc))
+- [#282](https://github.com/luigi-project/luigi/pull/282) Add short README.md file about Luigi Core ([@bszwarc](https://github.com/bszwarc))
 
 ## [v0.4.0] - 2018-12-06
 
 #### :rocket: Added
 
-- [#259](https://github.com/SAP/luigi/pull/259) Nav collapsed feature ([@parostatkiem](https://github.com/parostatkiem))
-- [#247](https://github.com/SAP/luigi/pull/247) Luigi view components design upgrade ([@antiheld](https://github.com/antiheld))
+- [#259](https://github.com/luigi-project/luigi/pull/259) Nav collapsed feature ([@parostatkiem](https://github.com/parostatkiem))
+- [#247](https://github.com/luigi-project/luigi/pull/247) Luigi view components design upgrade ([@antiheld](https://github.com/antiheld))
 
 #### :bug: Fixed
 
-- [#226](https://github.com/SAP/luigi/pull/226) Add check if modules are same domain ([@dariadomagala](https://github.com/dariadomagala))
-- [#266](https://github.com/SAP/luigi/pull/266) Fixes for browser incompatibilities ([@pekura](https://github.com/pekura))
-- [#253](https://github.com/SAP/luigi/pull/253) Allow async defaultChildNode ([@maxmarkus](https://github.com/maxmarkus))
-- [#261](https://github.com/SAP/luigi/pull/261) Fix the relative path bug ([@dariadomagala](https://github.com/dariadomagala))
-- [#250](https://github.com/SAP/luigi/pull/250) preserveView should allow viewUrls with query params ([@maxmarkus](https://github.com/maxmarkus))
-- [#246](https://github.com/SAP/luigi/pull/246) Luigi Client creates extra entry in browser navigation history ([@pekura](https://github.com/pekura))
-- [#238](https://github.com/SAP/luigi/pull/238) viewUrl should not be mandatory in dynamic node ([@maxmarkus](https://github.com/maxmarkus))
+- [#226](https://github.com/luigi-project/luigi/pull/226) Add check if modules are same domain ([@dariadomagala](https://github.com/dariadomagala))
+- [#266](https://github.com/luigi-project/luigi/pull/266) Fixes for browser incompatibilities ([@pekura](https://github.com/pekura))
+- [#253](https://github.com/luigi-project/luigi/pull/253) Allow async defaultChildNode ([@maxmarkus](https://github.com/maxmarkus))
+- [#261](https://github.com/luigi-project/luigi/pull/261) Fix the relative path bug ([@dariadomagala](https://github.com/dariadomagala))
+- [#250](https://github.com/luigi-project/luigi/pull/250) preserveView should allow viewUrls with query params ([@maxmarkus](https://github.com/maxmarkus))
+- [#246](https://github.com/luigi-project/luigi/pull/246) Luigi Client creates extra entry in browser navigation history ([@pekura](https://github.com/pekura))
+- [#238](https://github.com/luigi-project/luigi/pull/238) viewUrl should not be mandatory in dynamic node ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#262](https://github.com/SAP/luigi/pull/262) Add improvements to Luigi Client API comments and annotations ([@bszwarc](https://github.com/bszwarc))
-- [#251](https://github.com/SAP/luigi/pull/251) Improvements for dex auth ([@maxmarkus](https://github.com/maxmarkus))
-- [#241](https://github.com/SAP/luigi/pull/241) Include v0.3.8 in changelog ([@kwiatekus](https://github.com/kwiatekus))
-- [#240](https://github.com/SAP/luigi/pull/240) Improve luigi client docu and generate new ([@jesusreal](https://github.com/jesusreal))
+- [#262](https://github.com/luigi-project/luigi/pull/262) Add improvements to Luigi Client API comments and annotations ([@bszwarc](https://github.com/bszwarc))
+- [#251](https://github.com/luigi-project/luigi/pull/251) Improvements for dex auth ([@maxmarkus](https://github.com/maxmarkus))
+- [#241](https://github.com/luigi-project/luigi/pull/241) Include v0.3.8 in changelog ([@kwiatekus](https://github.com/kwiatekus))
+- [#240](https://github.com/luigi-project/luigi/pull/240) Improve luigi client docu and generate new ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.3.8] - 2018-11-23
 
 #### :rocket: Added
 
-- [#190](https://github.com/SAP/luigi/pull/190) Context Switcher in top navigation ([@maxmarkus](https://github.com/maxmarkus))
-- [#209](https://github.com/SAP/luigi/pull/209) Support navigation nodes that just link to other nodes ([@jesusreal](https://github.com/jesusreal))
-- [#162](https://github.com/SAP/luigi/pull/162) 404 support for non existing paths ([@parostatkiem](https://github.com/parostatkiem))
-- [#187](https://github.com/SAP/luigi/pull/187) Luigi Core config refactorings ([@jesusreal](https://github.com/jesusreal))
-- [#200](https://github.com/SAP/luigi/pull/200) Align luigi header title with fundamental style ([@parostatkiem](https://github.com/parostatkiem))
-- [#180](https://github.com/SAP/luigi/pull/180) Token refresh ([@y-kkamil](https://github.com/y-kkamil))
-- [#160](https://github.com/SAP/luigi/pull/160) Configurable logo and title ([@maxmarkus](https://github.com/maxmarkus))
+- [#190](https://github.com/luigi-project/luigi/pull/190) Context Switcher in top navigation ([@maxmarkus](https://github.com/maxmarkus))
+- [#209](https://github.com/luigi-project/luigi/pull/209) Support navigation nodes that just link to other nodes ([@jesusreal](https://github.com/jesusreal))
+- [#162](https://github.com/luigi-project/luigi/pull/162) 404 support for non existing paths ([@parostatkiem](https://github.com/parostatkiem))
+- [#187](https://github.com/luigi-project/luigi/pull/187) Luigi Core config refactorings ([@jesusreal](https://github.com/jesusreal))
+- [#200](https://github.com/luigi-project/luigi/pull/200) Align luigi header title with fundamental style ([@parostatkiem](https://github.com/parostatkiem))
+- [#180](https://github.com/luigi-project/luigi/pull/180) Token refresh ([@y-kkamil](https://github.com/y-kkamil))
+- [#160](https://github.com/luigi-project/luigi/pull/160) Configurable logo and title ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#235](https://github.com/SAP/luigi/pull/235) Issues with path routing ([@jesusreal](https://github.com/jesusreal))
-- [#234](https://github.com/SAP/luigi/pull/234) Add logout.html to webpack config ([@kwiatekus](https://github.com/kwiatekus))
-- [#232](https://github.com/SAP/luigi/pull/232) Fix no context switcher error ([@pekura](https://github.com/pekura))
-- [#224](https://github.com/SAP/luigi/pull/224) Bugfix/preserve view content area ([@maxmarkus](https://github.com/maxmarkus))
-- [#222](https://github.com/SAP/luigi/pull/222) Login fix ([@hardl](https://github.com/hardl))
-- [#202](https://github.com/SAP/luigi/pull/202) Fix go-back-button bug ([@parostatkiem](https://github.com/parostatkiem))
-- [#215](https://github.com/SAP/luigi/pull/215) mock auth logout page fix ([@y-kkamil](https://github.com/y-kkamil))
-- [#211](https://github.com/SAP/luigi/pull/211) Multiple path parameters do not get replaced in view url ([@pekura](https://github.com/pekura))
-- [#212](https://github.com/SAP/luigi/pull/212) Fix failing unit tests ([@dariadomagala](https://github.com/dariadomagala))
-- [#206](https://github.com/SAP/luigi/pull/206) Center the logo ([@dariadomagala](https://github.com/dariadomagala))
-- [#196](https://github.com/SAP/luigi/pull/196) Fix for goBack when not using micro frontend without routing ([@maxmarkus](https://github.com/maxmarkus))
-- [#177](https://github.com/SAP/luigi/pull/177) Allow multiple init and update listeners ([@maxmarkus](https://github.com/maxmarkus))
+- [#235](https://github.com/luigi-project/luigi/pull/235) Issues with path routing ([@jesusreal](https://github.com/jesusreal))
+- [#234](https://github.com/luigi-project/luigi/pull/234) Add logout.html to webpack config ([@kwiatekus](https://github.com/kwiatekus))
+- [#232](https://github.com/luigi-project/luigi/pull/232) Fix no context switcher error ([@pekura](https://github.com/pekura))
+- [#224](https://github.com/luigi-project/luigi/pull/224) Bugfix/preserve view content area ([@maxmarkus](https://github.com/maxmarkus))
+- [#222](https://github.com/luigi-project/luigi/pull/222) Login fix ([@hardl](https://github.com/hardl))
+- [#202](https://github.com/luigi-project/luigi/pull/202) Fix go-back-button bug ([@parostatkiem](https://github.com/parostatkiem))
+- [#215](https://github.com/luigi-project/luigi/pull/215) mock auth logout page fix ([@y-kkamil](https://github.com/y-kkamil))
+- [#211](https://github.com/luigi-project/luigi/pull/211) Multiple path parameters do not get replaced in view url ([@pekura](https://github.com/pekura))
+- [#212](https://github.com/luigi-project/luigi/pull/212) Fix failing unit tests ([@dariadomagala](https://github.com/dariadomagala))
+- [#206](https://github.com/luigi-project/luigi/pull/206) Center the logo ([@dariadomagala](https://github.com/dariadomagala))
+- [#196](https://github.com/luigi-project/luigi/pull/196) Fix for goBack when not using micro frontend without routing ([@maxmarkus](https://github.com/maxmarkus))
+- [#177](https://github.com/luigi-project/luigi/pull/177) Allow multiple init and update listeners ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :memo: Documentation
 
-- [#197](https://github.com/SAP/luigi/pull/197) Improve luigi-client js docs ([@kwiatekus](https://github.com/kwiatekus))
-- [#155](https://github.com/SAP/luigi/pull/155) Describe get path params and get node params better ([@pekura](https://github.com/pekura))
-- [#199](https://github.com/SAP/luigi/pull/199) Add missing line and improve wording ([@bszwarc](https://github.com/bszwarc))
+- [#197](https://github.com/luigi-project/luigi/pull/197) Improve luigi-client js docs ([@kwiatekus](https://github.com/kwiatekus))
+- [#155](https://github.com/luigi-project/luigi/pull/155) Describe get path params and get node params better ([@pekura](https://github.com/pekura))
+- [#199](https://github.com/luigi-project/luigi/pull/199) Add missing line and improve wording ([@bszwarc](https://github.com/bszwarc))
 
 ## [v0.3.7] - 2018-10-31
 
 #### :rocket: Added
 
-- [#169](https://github.com/SAP/luigi/pull/169) Enable Luigi Client (micro frontend) to check whether a path exists in the main app ([@jesusreal](https://github.com/jesusreal))
+- [#169](https://github.com/luigi-project/luigi/pull/169) Enable Luigi Client (micro frontend) to check whether a path exists in the main app ([@jesusreal](https://github.com/jesusreal))
 
 #### :bug: Fixed
 
-- [#168](https://github.com/SAP/luigi/pull/168) Fix bug for closest parent navigation on Luigi Client ([@jesusreal](https://github.com/jesusreal))
+- [#168](https://github.com/luigi-project/luigi/pull/168) Fix bug for closest parent navigation on Luigi Client ([@jesusreal](https://github.com/jesusreal))
 
 #### :memo: Documentation
 
-- [#138](https://github.com/SAP/luigi/pull/138) Add details about navigation nodes and reading node parameters ([@bszwarc](https://github.com/bszwarc))
-- [#176](https://github.com/SAP/luigi/pull/176) Update and improve the content of the installation guide ([@bszwarc](https://github.com/bszwarc))
-- [#161](https://github.com/SAP/luigi/pull/161) Fix small docu bugs ([@jesusreal](https://github.com/jesusreal))
+- [#138](https://github.com/luigi-project/luigi/pull/138) Add details about navigation nodes and reading node parameters ([@bszwarc](https://github.com/bszwarc))
+- [#176](https://github.com/luigi-project/luigi/pull/176) Update and improve the content of the installation guide ([@bszwarc](https://github.com/bszwarc))
+- [#161](https://github.com/luigi-project/luigi/pull/161) Fix small docu bugs ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.3.6] - 2018-10-23
 
 #### :rocket: Added
 
-- [#131](https://github.com/SAP/luigi/pull/131) Make automatic login configurable ([@dariadomagala](https://github.com/dariadomagala))
-- [#121](https://github.com/SAP/luigi/pull/121) Navigation node as a link to an external page ([@parostatkiem](https://github.com/parostatkiem))
-- [#118](https://github.com/SAP/luigi/pull/118) Keep left-side navigation on a node hierarchy level ([@maxmarkus](https://github.com/maxmarkus))
-- [#129](https://github.com/SAP/luigi/pull/129) Add automatic loading indicator to show processing ([@maxmarkus](https://github.com/maxmarkus))
-- [#105](https://github.com/SAP/luigi/pull/105) Enable e2e tests ([@dariadomagala](https://github.com/dariadomagala))
-- [#142](https://github.com/SAP/luigi/pull/142) View preservation is now allowed also cross-domain ([@maxmarkus](https://github.com/maxmarkus))
+- [#131](https://github.com/luigi-project/luigi/pull/131) Make automatic login configurable ([@dariadomagala](https://github.com/dariadomagala))
+- [#121](https://github.com/luigi-project/luigi/pull/121) Navigation node as a link to an external page ([@parostatkiem](https://github.com/parostatkiem))
+- [#118](https://github.com/luigi-project/luigi/pull/118) Keep left-side navigation on a node hierarchy level ([@maxmarkus](https://github.com/maxmarkus))
+- [#129](https://github.com/luigi-project/luigi/pull/129) Add automatic loading indicator to show processing ([@maxmarkus](https://github.com/maxmarkus))
+- [#105](https://github.com/luigi-project/luigi/pull/105) Enable e2e tests ([@dariadomagala](https://github.com/dariadomagala))
+- [#142](https://github.com/luigi-project/luigi/pull/142) View preservation is now allowed also cross-domain ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#140](https://github.com/SAP/luigi/pull/140) Fix css issues in core and angular example ([@jesusreal](https://github.com/jesusreal))
-- [#116](https://github.com/SAP/luigi/pull/116) Change per-component backdrop to global one ([@parostatkiem](https://github.com/parostatkiem))
-- [#120](https://github.com/SAP/luigi/pull/120) Fix fonts bundling in luigi core ([@parostatkiem](https://github.com/parostatkiem))
-- [#115](https://github.com/SAP/luigi/pull/115) Re-login not redirecting to luigi app ([@jesusreal](https://github.com/jesusreal))
+- [#140](https://github.com/luigi-project/luigi/pull/140) Fix css issues in core and angular example ([@jesusreal](https://github.com/jesusreal))
+- [#116](https://github.com/luigi-project/luigi/pull/116) Change per-component backdrop to global one ([@parostatkiem](https://github.com/parostatkiem))
+- [#120](https://github.com/luigi-project/luigi/pull/120) Fix fonts bundling in luigi core ([@parostatkiem](https://github.com/parostatkiem))
+- [#115](https://github.com/luigi-project/luigi/pull/115) Re-login not redirecting to luigi app ([@jesusreal](https://github.com/jesusreal))
 
 #### :memo: Documentation
 
-- [#148](https://github.com/SAP/luigi/pull/148) Copy template for security issues ([@franpog859](https://github.com/franpog859))
-- [#135](https://github.com/SAP/luigi/pull/135) Improve getting started documentation ([@maxmarkus](https://github.com/maxmarkus))
-- [#137](https://github.com/SAP/luigi/pull/137) Add autogenerated luigi client api docs ([@jesusreal](https://github.com/jesusreal))
+- [#148](https://github.com/luigi-project/luigi/pull/148) Copy template for security issues ([@franpog859](https://github.com/franpog859))
+- [#135](https://github.com/luigi-project/luigi/pull/135) Improve getting started documentation ([@maxmarkus](https://github.com/maxmarkus))
+- [#137](https://github.com/luigi-project/luigi/pull/137) Add autogenerated luigi client api docs ([@jesusreal](https://github.com/jesusreal))
 
 ## [v0.3.5] - 2018-09-26
 
 #### :rocket: Added
 
-- [#104](https://github.com/SAP/luigi/pull/104) Dynamic pathSegments in navigation nodes ([@maxmarkus](https://github.com/maxmarkus))
+- [#104](https://github.com/luigi-project/luigi/pull/104) Dynamic pathSegments in navigation nodes ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#84](https://github.com/SAP/luigi/pull/84) Remove unnecessary files from public folder ([@dariadomagala](https://github.com/dariadomagala))
-- [#103](https://github.com/SAP/luigi/pull/103) Fix behavior of the logout dropdown ([@dariadomagala](https://github.com/dariadomagala))
-- [#102](https://github.com/SAP/luigi/pull/102) Fix 'preserve view' feature for sibiling nodes ([@maxmarkus](https://github.com/maxmarkus))
-- [#89](https://github.com/SAP/luigi/pull/89) Fix unnecessary 'authSuccessfull' handler execution on each page refresh ([@dariadomagala](https://github.com/dariadomagala))
-- [#79](https://github.com/SAP/luigi/pull/79) Fix fundamental-ui issues in applications setup docu ([@jesusreal](https://github.com/jesusreal))
+- [#84](https://github.com/luigi-project/luigi/pull/84) Remove unnecessary files from public folder ([@dariadomagala](https://github.com/dariadomagala))
+- [#103](https://github.com/luigi-project/luigi/pull/103) Fix behavior of the logout dropdown ([@dariadomagala](https://github.com/dariadomagala))
+- [#102](https://github.com/luigi-project/luigi/pull/102) Fix 'preserve view' feature for sibiling nodes ([@maxmarkus](https://github.com/maxmarkus))
+- [#89](https://github.com/luigi-project/luigi/pull/89) Fix unnecessary 'authSuccessfull' handler execution on each page refresh ([@dariadomagala](https://github.com/dariadomagala))
+- [#79](https://github.com/luigi-project/luigi/pull/79) Fix fundamental-ui issues in applications setup docu ([@jesusreal](https://github.com/jesusreal))
 
 #### :memo: Documentation
 
-- [#107](https://github.com/SAP/luigi/pull/107) Commands path info in angular example readme ([@parostatkiem](https://github.com/parostatkiem))
+- [#107](https://github.com/luigi-project/luigi/pull/107) Commands path info in angular example readme ([@parostatkiem](https://github.com/parostatkiem))
 
 ## [core-0.3.3] - 2018-09-14
 
 #### :rocket: Added
 
-- [#67](https://github.com/SAP/luigi/pull/67) Navigation node visibility with custom nodeAccessibilityResolver ([@maxmarkus](https://github.com/maxmarkus))
+- [#67](https://github.com/luigi-project/luigi/pull/67) Navigation node visibility with custom nodeAccessibilityResolver ([@maxmarkus](https://github.com/maxmarkus))
 
 #### :bug: Fixed
 
-- [#82](https://github.com/SAP/luigi/pull/82) Fixed changedetector bug ([@dariadomagala](https://github.com/dariadomagala))
-- [#71](https://github.com/SAP/luigi/pull/71) Fixed top navigation popover behavior ([@maxmarkus](https://github.com/maxmarkus))
-- [#76](https://github.com/SAP/luigi/pull/76) Fixed broken routing after successful OIDC authentication ([@maxmarkus](https://github.com/maxmarkus))
-- [#57](https://github.com/SAP/luigi/pull/57) Fixed preserve view and back example ([@dariadomagala](https://github.com/dariadomagala))
-- [#75](https://github.com/SAP/luigi/pull/75) Fixed import of LuigiClient on angular app ([@jesusreal](https://github.com/jesusreal))
+- [#82](https://github.com/luigi-project/luigi/pull/82) Fixed changedetector bug ([@dariadomagala](https://github.com/dariadomagala))
+- [#71](https://github.com/luigi-project/luigi/pull/71) Fixed top navigation popover behavior ([@maxmarkus](https://github.com/maxmarkus))
+- [#76](https://github.com/luigi-project/luigi/pull/76) Fixed broken routing after successful OIDC authentication ([@maxmarkus](https://github.com/maxmarkus))
+- [#57](https://github.com/luigi-project/luigi/pull/57) Fixed preserve view and back example ([@dariadomagala](https://github.com/dariadomagala))
+- [#75](https://github.com/luigi-project/luigi/pull/75) Fixed import of LuigiClient on angular app ([@jesusreal](https://github.com/jesusreal))
 
 #### :memo: Documentation
 
-- [#80](https://github.com/SAP/luigi/pull/80) Luigi documentation refinements ([@dpolitesap](https://github.com/dpolitesap))
-- [#34](https://github.com/SAP/luigi/pull/34) Introduce changelog file ([@jesusreal](https://github.com/jesusreal))
+- [#80](https://github.com/luigi-project/luigi/pull/80) Luigi documentation refinements ([@dpolitesap](https://github.com/dpolitesap))
+- [#34](https://github.com/luigi-project/luigi/pull/34) Introduce changelog file ([@jesusreal](https://github.com/jesusreal))
 
 ## [client-0.3.2] - 2018-09-10
 
 #### :rocket: Added
 
-- [#33](https://github.com/SAP/luigi/pull/33) Ensure es5 compliance for luigi client ([@y-kkamil](https://github.com/y-kkamil))
+- [#33](https://github.com/luigi-project/luigi/pull/33) Ensure es5 compliance for luigi client ([@y-kkamil](https://github.com/y-kkamil))
 
 ## [core-0.3.1] - 2018-09-07
 
 #### :bug: Fixed
 
-- [#31](https://github.com/SAP/luigi/pull/31) Redirect from root node to first child ([@y-kkamil](https://github.com/y-kkamil))
-- [#50](https://github.com/SAP/luigi/pull/50) #49 [fix] OAuth2 implicit grant flow should use GET as default reques… ([@aartek](https://github.com/aartek))
+- [#31](https://github.com/luigi-project/luigi/pull/31) Redirect from root node to first child ([@y-kkamil](https://github.com/y-kkamil))
+- [#50](https://github.com/luigi-project/luigi/pull/50) #49 [fix] OAuth2 implicit grant flow should use GET as default reques… ([@aartek](https://github.com/aartek))
 
 ## [core-0.3.0] - 2018-09-05
 
@@ -1906,132 +1906,132 @@ The lerna-changelog tool detects changes based on PR labels and maps them to sec
 - Client: Link manager for navigation.
 - Client: UX manager for backdrop.
 
-[core-0.3.0]: https://github.com/SAP/luigi/compare/v0.2.1...core-0.3.0
-[core-0.3.1]: https://github.com/SAP/luigi/compare/core-0.3.0...core-0.3.1
-[core-0.3.3]: https://github.com/SAP/luigi/compare/core-0.3.2...core-0.3.3
-[client-0.3.2]: https://github.com/SAP/luigi/compare/client-0.3.1...client-0.3.2
-[client-0.3.0]: https://github.com/SAP/luigi/compare/v0.2.1...client-0.3.0
-[v0.3.5]: https://github.com/SAP/luigi/compare/core-0.3.3...v0.3.5
-[v0.3.6]: https://github.com/SAP/luigi/compare/v0.3.5...v0.3.6
-[v0.3.7]: https://github.com/SAP/luigi/compare/v0.3.6...v0.3.7
-[v0.3.8]: https://github.com/SAP/luigi/compare/v0.3.7...v0.3.8
-[v0.4.0]: https://github.com/SAP/luigi/compare/v0.3.8...v0.4.0
-[v0.4.1]: https://github.com/SAP/luigi/compare/v0.4.0...v0.4.1
-[v0.4.3]: https://github.com/SAP/luigi/compare/v0.4.2...v0.4.3
-[v0.4.4]: https://github.com/SAP/luigi/compare/v0.4.3...v0.4.4
-[v0.4.5]: https://github.com/SAP/luigi/compare/v0.4.4...v0.4.5
-[v0.4.9]: https://github.com/SAP/luigi/compare/v0.4.8...v0.4.9
-[v0.4.10]: https://github.com/SAP/luigi/compare/v0.4.9...v0.4.10
-[v0.4.11]: https://github.com/SAP/luigi/compare/v0.4.10...v0.4.11
-[v0.4.12]: https://github.com/SAP/luigi/compare/v0.4.11...v0.4.12
-[v0.5.0]: https://github.com/SAP/luigi/compare/v0.4.12...v0.5.0
-[v0.5.1]: https://github.com/SAP/luigi/compare/v0.5.0...v0.5.1
-[v0.5.2]: https://github.com/SAP/luigi/compare/v0.5.1...v0.5.2
-[v0.5.3]: https://github.com/SAP/luigi/compare/v0.5.2...v0.5.3
-[v0.5.4]: https://github.com/SAP/luigi/compare/v0.5.3...v0.5.4
-[v0.6.0]: https://github.com/SAP/luigi/compare/v0.5.4...v0.6.0
-[v0.6.1]: https://github.com/SAP/luigi/compare/v0.6.0...v0.6.1
-[v0.6.2]: https://github.com/SAP/luigi/compare/v0.6.1...v0.6.2
-[v0.6.3]: https://github.com/SAP/luigi/compare/v0.6.2...v0.6.3
-[v0.6.4]: https://github.com/SAP/luigi/compare/v0.6.3...v0.6.4
-[v0.6.5]: https://github.com/SAP/luigi/compare/v0.6.4...v0.6.5
-[v0.6.6]: https://github.com/SAP/luigi/compare/v0.6.5...v0.6.6
-[v0.7.0]: https://github.com/SAP/luigi/compare/v0.6.6...v0.7.0
-[v0.7.1]: https://github.com/SAP/luigi/compare/v0.7.0...v0.7.1
-[v0.7.2]: https://github.com/SAP/luigi/compare/v0.7.1...v0.7.2
-[v0.7.3]: https://github.com/SAP/luigi/compare/v0.7.2...v0.7.3
-[v0.7.4]: https://github.com/SAP/luigi/compare/v0.7.3...v0.7.4
-[v0.7.5]: https://github.com/SAP/luigi/compare/v0.7.4...v0.7.5
-[v0.7.6]: https://github.com/SAP/luigi/compare/v0.7.5...v0.7.6
-[v0.7.7]: https://github.com/SAP/luigi/compare/v0.7.6...v0.7.7
-[v1.0.0]: https://github.com/SAP/luigi/compare/v0.7.7...v1.0.0
-[v1.0.1]: https://github.com/SAP/luigi/compare/v1.0.0...v1.0.1
-[v1.1.0]: https://github.com/SAP/luigi/compare/v1.0.1...v1.1.0
-[v1.1.1]: https://github.com/SAP/luigi/compare/v1.1.0...v1.1.1
-[v1.2.1]: https://github.com/SAP/luigi/compare/v1.1.1...v1.2.1
-[v1.2.2]: https://github.com/SAP/luigi/compare/v1.2.1...v1.2.2
-[v1.2.3]: https://github.com/SAP/luigi/compare/v1.2.2...v1.2.3
-[v1.2.4]: https://github.com/SAP/luigi/compare/v1.2.3...v1.2.4
-[v1.3.0]: https://github.com/SAP/luigi/compare/v1.2.4...v1.3.0
-[v1.3.1]: https://github.com/SAP/luigi/compare/v1.3.0...v1.3.1
-[v1.4.0]: https://github.com/SAP/luigi/compare/v1.3.1...v1.4.0
-[v1.5.0]: https://github.com/SAP/luigi/compare/v1.4.0...v1.5.0
-[v1.6.0]: https://github.com/SAP/luigi/compare/v1.5.0...v1.6.0
-[v1.7.0]: https://github.com/SAP/luigi/compare/v1.6.0...v1.7.0
-[v1.7.1]: https://github.com/SAP/luigi/compare/v1.7.0...v1.7.1
-[v1.8.0]: https://github.com/SAP/luigi/compare/v1.7.1...v1.8.0
-[v1.8.1]: https://github.com/SAP/luigi/compare/v1.8.0...v1.8.1
-[v1.9.0]: https://github.com/SAP/luigi/compare/v1.8.1...v1.9.0
-[v1.10.0]: https://github.com/SAP/luigi/compare/v1.9.0...v1.10.0
-[v1.11.0]: https://github.com/SAP/luigi/compare/v1.10.0...v1.11.0
-[v1.12.0]: https://github.com/SAP/luigi/compare/v1.11.0...v1.12.0
-[v1.12.1]: https://github.com/SAP/luigi/compare/v1.12.0...v1.12.1
-[v1.13.0]: https://github.com/SAP/luigi/compare/v1.12.1...v1.13.0
-[v1.14.0]: https://github.com/SAP/luigi/compare/v1.13.0...v1.14.0
-[v1.14.1]: https://github.com/SAP/luigi/compare/v1.14.0...v1.14.1
-[v1.14.2]: https://github.com/SAP/luigi/compare/v1.14.1...v1.14.2
-[v1.14.3]: https://github.com/SAP/luigi/compare/v1.14.2...v1.14.3
-[v1.15.0]: https://github.com/SAP/luigi/compare/v1.14.3...v1.15.0
-[v1.16.0]: https://github.com/SAP/luigi/compare/v1.15.0...v1.16.0
-[v1.16.1]: https://github.com/SAP/luigi/compare/v1.16.0...v1.16.1
-[v1.16.2]: https://github.com/SAP/luigi/compare/v1.16.1...v1.16.2
-[v1.17.0]: https://github.com/SAP/luigi/compare/v1.16.2...v1.17.0
-[v1.18.0]: https://github.com/SAP/luigi/compare/v1.17.0...v1.18.0
-[v1.18.1]: https://github.com/SAP/luigi/compare/v1.18.0...v1.18.1
-[v1.19.0]: https://github.com/SAP/luigi/compare/v1.18.1...v1.19.0
-[v1.20.0]: https://github.com/SAP/luigi/compare/v1.19.0...v1.20.0
-[v1.20.1]: https://github.com/SAP/luigi/compare/v1.20.0...v1.20.1
-[v1.21.0]: https://github.com/SAP/luigi/compare/v1.20.1...v1.21.0
-[v1.22.0]: https://github.com/SAP/luigi/compare/v1.21.0...v1.22.0
-[v1.23.0]: https://github.com/SAP/luigi/compare/v1.22.0...v1.23.0
-[v1.23.1]: https://github.com/SAP/luigi/compare/v1.23.0...v1.23.1
-[v1.24.0]: https://github.com/SAP/luigi/compare/v1.23.1...v1.24.0
-[v1.25.0]: https://github.com/SAP/luigi/compare/v1.24.0...v1.25.0
-[v1.25.1]: https://github.com/SAP/luigi/compare/v1.25.0...v1.25.1
-[v1.26.0]: https://github.com/SAP/luigi/compare/v1.25.1...v1.26.0
-[v2.0.0]: https://github.com/SAP/luigi/compare/v1.25.1...v2.0.0
-[v2.0.1]: https://github.com/SAP/luigi/compare/v2.0.0...v2.0.1
-[v2.1.0]: https://github.com/SAP/luigi/compare/v2.0.1...v2.1.0
-[v2.2.0]: https://github.com/SAP/luigi/compare/v2.1.0...v2.2.0
-[v2.2.1]: https://github.com/SAP/luigi/compare/v2.2.0...v2.2.1
-[v2.3.0]: https://github.com/SAP/luigi/compare/v2.2.1...v2.3.0
-[v2.4.0]: https://github.com/SAP/luigi/compare/v2.3.0...v2.4.0
-[v2.5.0]: https://github.com/SAP/luigi/compare/v2.4.0...v2.5.0
-[v2.5.1]: https://github.com/SAP/luigi/compare/v2.5.0...v2.5.1
-[v2.6.0]: https://github.com/SAP/luigi/compare/v2.5.1...v2.6.0
-[v2.6.1]: https://github.com/SAP/luigi/compare/v2.6.0...v2.6.1
-[v2.6.2]: https://github.com/SAP/luigi/compare/v2.6.1...v2.6.2
-[v2.6.3]: https://github.com/SAP/luigi/compare/v2.6.2...v2.6.3
-[v2.7.0]: https://github.com/SAP/luigi/compare/v2.6.3...v2.7.0
-[v2.7.1]: https://github.com/SAP/luigi/compare/v2.7.0...v2.7.1
-[v2.7.2]: https://github.com/SAP/luigi/compare/v2.7.1...v2.7.2
-[v2.7.3]: https://github.com/SAP/luigi/compare/v2.7.2...v2.7.3
-[v2.7.4]: https://github.com/SAP/luigi/compare/v2.7.3...v2.7.4
-[v2.7.5]: https://github.com/SAP/luigi/compare/v2.7.4...v2.7.5
-[v2.8.0]: https://github.com/SAP/luigi/compare/v2.7.5...v2.8.0
-[v2.9.0]: https://github.com/SAP/luigi/compare/v2.8.0...v2.9.0
-[v2.10.0]: https://github.com/SAP/luigi/compare/v2.9.0...v2.10.0
-[v2.11.0]: https://github.com/SAP/luigi/compare/v2.10.0...v2.11.0
-[v2.12.0]: https://github.com/SAP/luigi/compare/v2.11.0...v2.12.0
-[v2.13.0]: https://github.com/SAP/luigi/compare/v2.12.0...v2.13.0
-[v2.14.0]: https://github.com/SAP/luigi/compare/v2.13.0...v2.14.0
-[v2.14.1]: https://github.com/SAP/luigi/compare/v2.14.0...v2.14.1
-[v2.14.2]: https://github.com/SAP/luigi/compare/v2.14.1...v2.14.2
-[v2.14.3]: https://github.com/SAP/luigi/compare/v2.14.2...v2.14.3
-[v2.15.0]: https://github.com/SAP/luigi/compare/v2.14.3...v2.15.0
-[v2.16.0]: https://github.com/SAP/luigi/compare/v2.15.0...v2.16.0
-[v2.17.0]: https://github.com/SAP/luigi/compare/v2.16.0...v2.17.0
-[v2.18.0]: https://github.com/SAP/luigi/compare/v2.17.0...v2.18.0
-[v2.18.1]: https://github.com/SAP/luigi/compare/v2.18.0...v2.18.1
-[v2.18.2]: https://github.com/SAP/luigi/compare/v2.18.1...v2.18.2
-[v2.18.3]: https://github.com/SAP/luigi/compare/v2.18.2...v2.18.3
-[v2.19.0]: https://github.com/SAP/luigi/compare/v2.18.3...v2.19.0
-[v2.19.1]: https://github.com/SAP/luigi/compare/v2.19.0...v2.19.1
-[v2.19.2]: https://github.com/SAP/luigi/compare/v2.19.1...v2.19.2
-[v2.20.0]: https://github.com/SAP/luigi/compare/v2.19.2...v2.20.0
-[v2.21.0]: https://github.com/SAP/luigi/compare/v2.20.0...v2.21.0
-[v2.21.1]: https://github.com/SAP/luigi/compare/v2.21.0...v2.21.1
-[v2.21.2]: https://github.com/SAP/luigi/compare/v2.21.1...v2.21.2
-[v2.21.3]: https://github.com/SAP/luigi/compare/v2.21.2...v2.21.3
-[v2.22.0]: https://github.com/SAP/luigi/compare/v2.21.3...v2.22.0
-[v2.22.1]: https://github.com/SAP/luigi/compare/v2.22.0...v2.22.1
+[core-0.3.0]: https://github.com/luigi-project/luigi/compare/v0.2.1...core-0.3.0
+[core-0.3.1]: https://github.com/luigi-project/luigi/compare/core-0.3.0...core-0.3.1
+[core-0.3.3]: https://github.com/luigi-project/luigi/compare/core-0.3.2...core-0.3.3
+[client-0.3.2]: https://github.com/luigi-project/luigi/compare/client-0.3.1...client-0.3.2
+[client-0.3.0]: https://github.com/luigi-project/luigi/compare/v0.2.1...client-0.3.0
+[v0.3.5]: https://github.com/luigi-project/luigi/compare/core-0.3.3...v0.3.5
+[v0.3.6]: https://github.com/luigi-project/luigi/compare/v0.3.5...v0.3.6
+[v0.3.7]: https://github.com/luigi-project/luigi/compare/v0.3.6...v0.3.7
+[v0.3.8]: https://github.com/luigi-project/luigi/compare/v0.3.7...v0.3.8
+[v0.4.0]: https://github.com/luigi-project/luigi/compare/v0.3.8...v0.4.0
+[v0.4.1]: https://github.com/luigi-project/luigi/compare/v0.4.0...v0.4.1
+[v0.4.3]: https://github.com/luigi-project/luigi/compare/v0.4.2...v0.4.3
+[v0.4.4]: https://github.com/luigi-project/luigi/compare/v0.4.3...v0.4.4
+[v0.4.5]: https://github.com/luigi-project/luigi/compare/v0.4.4...v0.4.5
+[v0.4.9]: https://github.com/luigi-project/luigi/compare/v0.4.8...v0.4.9
+[v0.4.10]: https://github.com/luigi-project/luigi/compare/v0.4.9...v0.4.10
+[v0.4.11]: https://github.com/luigi-project/luigi/compare/v0.4.10...v0.4.11
+[v0.4.12]: https://github.com/luigi-project/luigi/compare/v0.4.11...v0.4.12
+[v0.5.0]: https://github.com/luigi-project/luigi/compare/v0.4.12...v0.5.0
+[v0.5.1]: https://github.com/luigi-project/luigi/compare/v0.5.0...v0.5.1
+[v0.5.2]: https://github.com/luigi-project/luigi/compare/v0.5.1...v0.5.2
+[v0.5.3]: https://github.com/luigi-project/luigi/compare/v0.5.2...v0.5.3
+[v0.5.4]: https://github.com/luigi-project/luigi/compare/v0.5.3...v0.5.4
+[v0.6.0]: https://github.com/luigi-project/luigi/compare/v0.5.4...v0.6.0
+[v0.6.1]: https://github.com/luigi-project/luigi/compare/v0.6.0...v0.6.1
+[v0.6.2]: https://github.com/luigi-project/luigi/compare/v0.6.1...v0.6.2
+[v0.6.3]: https://github.com/luigi-project/luigi/compare/v0.6.2...v0.6.3
+[v0.6.4]: https://github.com/luigi-project/luigi/compare/v0.6.3...v0.6.4
+[v0.6.5]: https://github.com/luigi-project/luigi/compare/v0.6.4...v0.6.5
+[v0.6.6]: https://github.com/luigi-project/luigi/compare/v0.6.5...v0.6.6
+[v0.7.0]: https://github.com/luigi-project/luigi/compare/v0.6.6...v0.7.0
+[v0.7.1]: https://github.com/luigi-project/luigi/compare/v0.7.0...v0.7.1
+[v0.7.2]: https://github.com/luigi-project/luigi/compare/v0.7.1...v0.7.2
+[v0.7.3]: https://github.com/luigi-project/luigi/compare/v0.7.2...v0.7.3
+[v0.7.4]: https://github.com/luigi-project/luigi/compare/v0.7.3...v0.7.4
+[v0.7.5]: https://github.com/luigi-project/luigi/compare/v0.7.4...v0.7.5
+[v0.7.6]: https://github.com/luigi-project/luigi/compare/v0.7.5...v0.7.6
+[v0.7.7]: https://github.com/luigi-project/luigi/compare/v0.7.6...v0.7.7
+[v1.0.0]: https://github.com/luigi-project/luigi/compare/v0.7.7...v1.0.0
+[v1.0.1]: https://github.com/luigi-project/luigi/compare/v1.0.0...v1.0.1
+[v1.1.0]: https://github.com/luigi-project/luigi/compare/v1.0.1...v1.1.0
+[v1.1.1]: https://github.com/luigi-project/luigi/compare/v1.1.0...v1.1.1
+[v1.2.1]: https://github.com/luigi-project/luigi/compare/v1.1.1...v1.2.1
+[v1.2.2]: https://github.com/luigi-project/luigi/compare/v1.2.1...v1.2.2
+[v1.2.3]: https://github.com/luigi-project/luigi/compare/v1.2.2...v1.2.3
+[v1.2.4]: https://github.com/luigi-project/luigi/compare/v1.2.3...v1.2.4
+[v1.3.0]: https://github.com/luigi-project/luigi/compare/v1.2.4...v1.3.0
+[v1.3.1]: https://github.com/luigi-project/luigi/compare/v1.3.0...v1.3.1
+[v1.4.0]: https://github.com/luigi-project/luigi/compare/v1.3.1...v1.4.0
+[v1.5.0]: https://github.com/luigi-project/luigi/compare/v1.4.0...v1.5.0
+[v1.6.0]: https://github.com/luigi-project/luigi/compare/v1.5.0...v1.6.0
+[v1.7.0]: https://github.com/luigi-project/luigi/compare/v1.6.0...v1.7.0
+[v1.7.1]: https://github.com/luigi-project/luigi/compare/v1.7.0...v1.7.1
+[v1.8.0]: https://github.com/luigi-project/luigi/compare/v1.7.1...v1.8.0
+[v1.8.1]: https://github.com/luigi-project/luigi/compare/v1.8.0...v1.8.1
+[v1.9.0]: https://github.com/luigi-project/luigi/compare/v1.8.1...v1.9.0
+[v1.10.0]: https://github.com/luigi-project/luigi/compare/v1.9.0...v1.10.0
+[v1.11.0]: https://github.com/luigi-project/luigi/compare/v1.10.0...v1.11.0
+[v1.12.0]: https://github.com/luigi-project/luigi/compare/v1.11.0...v1.12.0
+[v1.12.1]: https://github.com/luigi-project/luigi/compare/v1.12.0...v1.12.1
+[v1.13.0]: https://github.com/luigi-project/luigi/compare/v1.12.1...v1.13.0
+[v1.14.0]: https://github.com/luigi-project/luigi/compare/v1.13.0...v1.14.0
+[v1.14.1]: https://github.com/luigi-project/luigi/compare/v1.14.0...v1.14.1
+[v1.14.2]: https://github.com/luigi-project/luigi/compare/v1.14.1...v1.14.2
+[v1.14.3]: https://github.com/luigi-project/luigi/compare/v1.14.2...v1.14.3
+[v1.15.0]: https://github.com/luigi-project/luigi/compare/v1.14.3...v1.15.0
+[v1.16.0]: https://github.com/luigi-project/luigi/compare/v1.15.0...v1.16.0
+[v1.16.1]: https://github.com/luigi-project/luigi/compare/v1.16.0...v1.16.1
+[v1.16.2]: https://github.com/luigi-project/luigi/compare/v1.16.1...v1.16.2
+[v1.17.0]: https://github.com/luigi-project/luigi/compare/v1.16.2...v1.17.0
+[v1.18.0]: https://github.com/luigi-project/luigi/compare/v1.17.0...v1.18.0
+[v1.18.1]: https://github.com/luigi-project/luigi/compare/v1.18.0...v1.18.1
+[v1.19.0]: https://github.com/luigi-project/luigi/compare/v1.18.1...v1.19.0
+[v1.20.0]: https://github.com/luigi-project/luigi/compare/v1.19.0...v1.20.0
+[v1.20.1]: https://github.com/luigi-project/luigi/compare/v1.20.0...v1.20.1
+[v1.21.0]: https://github.com/luigi-project/luigi/compare/v1.20.1...v1.21.0
+[v1.22.0]: https://github.com/luigi-project/luigi/compare/v1.21.0...v1.22.0
+[v1.23.0]: https://github.com/luigi-project/luigi/compare/v1.22.0...v1.23.0
+[v1.23.1]: https://github.com/luigi-project/luigi/compare/v1.23.0...v1.23.1
+[v1.24.0]: https://github.com/luigi-project/luigi/compare/v1.23.1...v1.24.0
+[v1.25.0]: https://github.com/luigi-project/luigi/compare/v1.24.0...v1.25.0
+[v1.25.1]: https://github.com/luigi-project/luigi/compare/v1.25.0...v1.25.1
+[v1.26.0]: https://github.com/luigi-project/luigi/compare/v1.25.1...v1.26.0
+[v2.0.0]: https://github.com/luigi-project/luigi/compare/v1.25.1...v2.0.0
+[v2.0.1]: https://github.com/luigi-project/luigi/compare/v2.0.0...v2.0.1
+[v2.1.0]: https://github.com/luigi-project/luigi/compare/v2.0.1...v2.1.0
+[v2.2.0]: https://github.com/luigi-project/luigi/compare/v2.1.0...v2.2.0
+[v2.2.1]: https://github.com/luigi-project/luigi/compare/v2.2.0...v2.2.1
+[v2.3.0]: https://github.com/luigi-project/luigi/compare/v2.2.1...v2.3.0
+[v2.4.0]: https://github.com/luigi-project/luigi/compare/v2.3.0...v2.4.0
+[v2.5.0]: https://github.com/luigi-project/luigi/compare/v2.4.0...v2.5.0
+[v2.5.1]: https://github.com/luigi-project/luigi/compare/v2.5.0...v2.5.1
+[v2.6.0]: https://github.com/luigi-project/luigi/compare/v2.5.1...v2.6.0
+[v2.6.1]: https://github.com/luigi-project/luigi/compare/v2.6.0...v2.6.1
+[v2.6.2]: https://github.com/luigi-project/luigi/compare/v2.6.1...v2.6.2
+[v2.6.3]: https://github.com/luigi-project/luigi/compare/v2.6.2...v2.6.3
+[v2.7.0]: https://github.com/luigi-project/luigi/compare/v2.6.3...v2.7.0
+[v2.7.1]: https://github.com/luigi-project/luigi/compare/v2.7.0...v2.7.1
+[v2.7.2]: https://github.com/luigi-project/luigi/compare/v2.7.1...v2.7.2
+[v2.7.3]: https://github.com/luigi-project/luigi/compare/v2.7.2...v2.7.3
+[v2.7.4]: https://github.com/luigi-project/luigi/compare/v2.7.3...v2.7.4
+[v2.7.5]: https://github.com/luigi-project/luigi/compare/v2.7.4...v2.7.5
+[v2.8.0]: https://github.com/luigi-project/luigi/compare/v2.7.5...v2.8.0
+[v2.9.0]: https://github.com/luigi-project/luigi/compare/v2.8.0...v2.9.0
+[v2.10.0]: https://github.com/luigi-project/luigi/compare/v2.9.0...v2.10.0
+[v2.11.0]: https://github.com/luigi-project/luigi/compare/v2.10.0...v2.11.0
+[v2.12.0]: https://github.com/luigi-project/luigi/compare/v2.11.0...v2.12.0
+[v2.13.0]: https://github.com/luigi-project/luigi/compare/v2.12.0...v2.13.0
+[v2.14.0]: https://github.com/luigi-project/luigi/compare/v2.13.0...v2.14.0
+[v2.14.1]: https://github.com/luigi-project/luigi/compare/v2.14.0...v2.14.1
+[v2.14.2]: https://github.com/luigi-project/luigi/compare/v2.14.1...v2.14.2
+[v2.14.3]: https://github.com/luigi-project/luigi/compare/v2.14.2...v2.14.3
+[v2.15.0]: https://github.com/luigi-project/luigi/compare/v2.14.3...v2.15.0
+[v2.16.0]: https://github.com/luigi-project/luigi/compare/v2.15.0...v2.16.0
+[v2.17.0]: https://github.com/luigi-project/luigi/compare/v2.16.0...v2.17.0
+[v2.18.0]: https://github.com/luigi-project/luigi/compare/v2.17.0...v2.18.0
+[v2.18.1]: https://github.com/luigi-project/luigi/compare/v2.18.0...v2.18.1
+[v2.18.2]: https://github.com/luigi-project/luigi/compare/v2.18.1...v2.18.2
+[v2.18.3]: https://github.com/luigi-project/luigi/compare/v2.18.2...v2.18.3
+[v2.19.0]: https://github.com/luigi-project/luigi/compare/v2.18.3...v2.19.0
+[v2.19.1]: https://github.com/luigi-project/luigi/compare/v2.19.0...v2.19.1
+[v2.19.2]: https://github.com/luigi-project/luigi/compare/v2.19.1...v2.19.2
+[v2.20.0]: https://github.com/luigi-project/luigi/compare/v2.19.2...v2.20.0
+[v2.21.0]: https://github.com/luigi-project/luigi/compare/v2.20.0...v2.21.0
+[v2.21.1]: https://github.com/luigi-project/luigi/compare/v2.21.0...v2.21.1
+[v2.21.2]: https://github.com/luigi-project/luigi/compare/v2.21.1...v2.21.2
+[v2.21.3]: https://github.com/luigi-project/luigi/compare/v2.21.2...v2.21.3
+[v2.22.0]: https://github.com/luigi-project/luigi/compare/v2.21.3...v2.22.0
+[v2.22.1]: https://github.com/luigi-project/luigi/compare/v2.22.0...v2.22.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,14 +14,14 @@ You are welcome to contribute with your pull requests. These steps explain the c
 3. [Add tests](#testing) for your code, especially if you are updating the Luigi Core and Client API.
 4. If you've changed APIs, update the documentation. You can find more details on how to do that [here](docs/content-guidelines.md/#API-documentation).
 5. If you are adding documentation, follow the [content guidelines](docs/content-guidelines.md).
-6. Make sure the tests pass. Our [pipeline](https://github.com/SAP/luigi/actions) is running the unit and e2e tests for your PR and will indicate any issues.
+6. Make sure the tests pass. Our [pipeline](https://github.com/luigi-project/luigi/actions) is running the unit and e2e tests for your PR and will indicate any issues.
 7. Sign the Developer Certificate of Origin (DCO).
 
 ## Testing
 
-> **NOTE:** You should always add [*unit tests*](https://github.com/SAP/luigi/tree/main/core/test) if you are adding code to our repository.
+> **NOTE:** You should always add [*unit tests*](https://github.com/luigi-project/luigi/tree/main/core/test) if you are adding code to our repository.
 
-If you've added code that is exposed as an API or configuration, additionally add e2e tests to [js-test-app](https://github.com/SAP/luigi/tree/main/test/e2e-test-application/cypress/e2e/tests/0-js-test-app).
+If you've added code that is exposed as an API or configuration, additionally add e2e tests to [js-test-app](https://github.com/luigi-project/luigi/tree/main/test/e2e-test-application/cypress/e2e/tests/0-js-test-app).
 
 To let tests run locally, run `cd test/e2e-js-test-application && npm run dev` and `cd test/e2e-test-application && npm run e2e:open` and click on the test in the *js-test-application* category.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://github.com/SAP/luigi/actions/workflows/test.yml/badge.svg)](https://github.com/SAP/luigi/actions/workflows/test.yml)
-[![REUSE status](https://api.reuse.software/badge/github.com/SAP/luigi)](https://api.reuse.software/info/github.com/SAP/luigi)
+[![Build Status](https://github.com/luigi-project/luigi/actions/workflows/test.yml/badge.svg)](https://github.com/luigi-project/luigi/actions/workflows/test.yml)
+[![REUSE status](https://api.reuse.software/badge/github.com/luigi-project/luigi)](https://api.reuse.software/info/github.com/SAP/luigi)
 # Luigi
 <p align="center">
- <img src="https://raw.githubusercontent.com/sap/luigi/main/logo.png" alt="Luigi logo" width="235">
+ <img src="https://raw.githubusercontent.com/luigi-project/luigi/main/logo.png" alt="Luigi logo" width="235">
 </p>
 
 ## Description
@@ -46,7 +46,7 @@ For security reasons, follow these guidelines when developing a micro frontend:
 - Maintain an allowlist with trusted domains and compare it with the origin of the Luigi Core application. The origin will be passed when you call the init listener in your micro frontend. Stop further processing if the origin does not match.
 
 
-> **NOTE**: Luigi follows these [sandbox rules for iframes](https://github.com/SAP/luigi/blob/af1deebb392dcec6490f72576e32eb5853a894bc/core/src/utilities/helpers/iframe-helpers.js#L140).
+> **NOTE**: Luigi follows these [sandbox rules for iframes](https://github.com/luigi-project/luigi/blob/af1deebb392dcec6490f72576e32eb5853a894bc/core/src/utilities/helpers/iframe-helpers.js#L140).
 
 
 ### Code formatting for contributors
@@ -59,10 +59,10 @@ To ensure that existing features still work as expected after your changes, run 
 
 ### E2E tests
 
-To ensure that existing features still work as expected after your changes, you need to run UI tests from the [Angular example application](https://github.com/SAP/luigi/tree/main/test/e2e-test-application). Before running the tests, you need to start our two test applications: 
+To ensure that existing features still work as expected after your changes, you need to run UI tests from the [Angular example application](https://github.com/luigi-project/luigi/tree/main/test/e2e-test-application). Before running the tests, you need to start our two test applications: 
 
-- Start the [Angular example application](https://github.com/SAP/luigi/tree/main/test/e2e-test-application) by using the `npm start` command in the application folder.
-- Start the [js test application](https://github.com/SAP/luigi/tree/main/test/e2e-js-test-application) by using the `npm run dev` command in the application folder.
+- Start the [Angular example application](https://github.com/luigi-project/luigi/tree/main/test/e2e-test-application) by using the `npm start` command in the application folder.
+- Start the [js test application](https://github.com/luigi-project/luigi/tree/main/test/e2e-js-test-application) by using the `npm run dev` command in the application folder.
 
 Once the applications are ready:
 
@@ -81,7 +81,7 @@ Install [jq](https://stedolan.github.io/jq/) using the `brew install jq` command
 
 ## How to obtain support
 
-If you have further questions about Luigi, you can check the [GitHub Discussions page](https://github.com/SAP/luigi/discussions) or contact us on our [Slack channel](https://slack.luigi-project.io/). If you find a specific problem or bug, you can also open a [GitHub issue](https://github.com/SAP/luigi/issues/new/choose) on our repository. Please describe the problem and the steps to reproduce it in your issue.
+If you have further questions about Luigi, you can check the [GitHub Discussions page](https://github.com/luigi-project/luigi/discussions) or contact us on our [Slack channel](https://slack.luigi-project.io/). If you find a specific problem or bug, you can also open a [GitHub issue](https://github.com/luigi-project/luigi/issues/new/choose) on our repository. Please describe the problem and the steps to reproduce it in your issue.
 
 ## Contributing
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,7 +1,7 @@
 version = 1
 SPDX-PackageName = "Luigi"
 SPDX-PackageSupplier = "Philipp Pracht <philipp.pracht@sap.com>"
-SPDX-PackageDownloadLocation = "https://github.com/SAP/luigi"
+SPDX-PackageDownloadLocation = "https://github.com/luigi-project/luigi"
 
 [[annotations]]
 path = "**"

--- a/blog/2020-07-16-release-notes.md
+++ b/blog/2020-07-16-release-notes.md
@@ -19,8 +19,8 @@ With Luigi version v1.3.0, the new v0.10.0 of Fundamental Library Styles were in
 
 #### Support for authorization code flow with PKCE
 
-If you use OIDC for authorization, you can now authenticate using [PKCE](https://oauth.net/2/pkce/). You can see the full changes in the code [here](https://github.com/SAP/luigi/pull/1478). Fun fact: this issue was fixed by an external developer. We'd like to remind you that Luigi is 100% open source and we love receiving contributions and suggestions on GitHub. If you have any ideas, don't hesitate to participate.
+If you use OIDC for authorization, you can now authenticate using [PKCE](https://oauth.net/2/pkce/). You can see the full changes in the code [here](https://github.com/luigi-project/luigi/pull/1478). Fun fact: this issue was fixed by an external developer. We'd like to remind you that Luigi is 100% open source and we love receiving contributions and suggestions on GitHub. If you have any ideas, don't hesitate to participate.
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2020-09-09-release-notes.md
+++ b/blog/2020-09-09-release-notes.md
@@ -19,7 +19,7 @@ As of v1.4.0, Luigi also offers support for feature toggles. [Feature toggles](h
 
 #### Luigi example with NextJS
 
-Have you ever wondered if you can use Luigi with NextJS? The answer is "yes", and in this release we included a new example Luigi application that is running on top of NextJS. You can install the example and try it yourself by following the steps [here](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-next).
+Have you ever wondered if you can use Luigi with NextJS? The answer is "yes", and in this release we included a new example Luigi application that is running on top of NextJS. You can install the example and try it yourself by following the steps [here](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-next).
 
 #### Fundamental Styles update
 
@@ -33,4 +33,4 @@ The Luigi Client API also includes a new function, [closeCurrentModal](https://d
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2020-10-28-release-notes.md
+++ b/blog/2020-10-28-release-notes.md
@@ -27,4 +27,4 @@ A new `disableInputHandlers` parameter was added to the [global search](https://
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2020-11-25-release-notes.md
+++ b/blog/2020-11-25-release-notes.md
@@ -19,4 +19,4 @@ It is now possible to open a micro frontend in a drawer. This feature can be imp
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2021-02-08-luigi-updates.md
+++ b/blog/2021-02-08-luigi-updates.md
@@ -13,11 +13,11 @@ In this blog post, you can read about the most important updates and new feature
 
 In Luigi v1.7.0, we introduced a great new feature - support for Web Components. This has the potential to add a lot of new capablities to your Luigi apps, including a simple way to include more than one micro frontend on one page. You can find more resources and tutorials about Web Components [here](https://developer.mozilla.org/en-US/docs/Web/Web_Components). You can find the documentation for web components on our website [here](https://docs.luigi-project.io/docs/web-component).
 
-An example of Luigi Web Components can be found on our sandbox application [Luigi Fiddle](https://fiddle.luigi-project.io/). You can click the "Modify Config" button to see how the Web Components are configured in Luigi. The full source code of Luigi Fiddle can also be found on our [GitHub repo](https://github.com/SAP/luigi/tree/main/website/fiddle), in case you also want to delve deeper into the example.
+An example of Luigi Web Components can be found on our sandbox application [Luigi Fiddle](https://fiddle.luigi-project.io/). You can click the "Modify Config" button to see how the Web Components are configured in Luigi. The full source code of Luigi Fiddle can also be found on our [GitHub repo](https://github.com/luigi-project/luigi/tree/main/website/fiddle), in case you also want to delve deeper into the example.
 
 #### Luigi Client Angular support library
 
-Also in v.1.7.0, we introduced a support library for Luigi Client in Angular. After you import the library to your project, you can use different features related to routing and contexts in Luigi. You can find more information about the library [here](https://github.com/SAP/luigi/tree/main/client-frameworks-support/client-support-angular).
+Also in v.1.7.0, we introduced a support library for Luigi Client in Angular. After you import the library to your project, you can use different features related to routing and contexts in Luigi. You can find more information about the library [here](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/client-support-angular).
 
 #### Fundamental Library Styles - breaking changes
 
@@ -29,4 +29,4 @@ With v.1.10.0, we introduced support for different types of confirmation modals.
 
 #### More features
 
-For a full list of new features and bugfixes, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of new features and bugfixes, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2021-06-07-release-notes.md
+++ b/blog/2021-06-07-release-notes.md
@@ -35,7 +35,7 @@ For more information, read the [documentation](https://docs.luigi-project.io/doc
 
 #### Dispatch hashchange event
 
-For viewGroup navigation, a new hashchange event is dispatched if the hash was changed, in order to support UI frameworks whose routers rely on this event. You can see the [PR](https://github.com/SAP/luigi/pull/2011) for more details.
+For viewGroup navigation, a new hashchange event is dispatched if the hash was changed, in order to support UI frameworks whose routers rely on this event. You can see the [PR](https://github.com/luigi-project/luigi/pull/2011) for more details.
 
 #### Introduce i18n variable in viewUrl
 
@@ -56,4 +56,4 @@ We added a new parameter that can be added to Luigi's routing configuration sect
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2021-06-22-release-notes.md
+++ b/blog/2021-06-22-release-notes.md
@@ -51,5 +51,5 @@ To make this easier, we included a new `reset` function in the Luigi Core API. Y
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2021-08-27-release-notes.md
+++ b/blog/2021-08-27-release-notes.md
@@ -31,5 +31,5 @@ You can read more in the documentation [here](https://docs.luigi-project.io/docs
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2021-10-14-release-notes.md
+++ b/blog/2021-10-14-release-notes.md
@@ -19,15 +19,15 @@ will be translated to its actual path: `http://localhost:4200/projects/pr2/setti
 
 #### Improved user settings
 
-The dropdown in Luigi's [user settings](https://docs.luigi-project.io/docs/user-settings) dialog was refactored to the latest Fiori3 specifications to be easily accessible via keyboard. You can find more information [here](https://github.com/SAP/luigi/pull/2293).
+The dropdown in Luigi's [user settings](https://docs.luigi-project.io/docs/user-settings) dialog was refactored to the latest Fiori3 specifications to be easily accessible via keyboard. You can find more information [here](https://github.com/luigi-project/luigi/pull/2293).
 
-Also, the Profile dropdown entities in user settings are now accessible via keyboard. You can learn more [here](https://github.com/SAP/luigi/pull/2256).
+Also, the Profile dropdown entities in user settings are now accessible via keyboard. You can learn more [here](https://github.com/luigi-project/luigi/pull/2256).
 
 #### getCurrentLocale works with Luigi Client Web Components
 
-With our newest release, you can use the [getCurrentLocale](https://docs.luigi-project.io/docs/luigi-client-api/?section=getcurrentlocale) function within [Web Components](https://docs.luigi-project.io/docs/web-component) of Luigi Client. For more information see the changes [here](https://github.com/SAP/luigi/pull/2219).
+With our newest release, you can use the [getCurrentLocale](https://docs.luigi-project.io/docs/luigi-client-api/?section=getcurrentlocale) function within [Web Components](https://docs.luigi-project.io/docs/web-component) of Luigi Client. For more information see the changes [here](https://github.com/luigi-project/luigi/pull/2219).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2021-11-02-release-notes.md
+++ b/blog/2021-11-02-release-notes.md
@@ -27,7 +27,7 @@ Luigi.setConfig({
 })
 ```
 
-You can find more information [here](https://github.com/SAP/luigi/pull/2304) or in the [general settings](https://docs.luigi-project.io/docs/general-settings) documentation.
+You can find more information [here](https://github.com/luigi-project/luigi/pull/2304) or in the [general settings](https://docs.luigi-project.io/docs/general-settings) documentation.
 
 
 #### TooltipText parameter
@@ -41,9 +41,9 @@ The new Luigi Client method `updateModalSettings` allows you to change the size 
 
 #### Core API templating for compound children and external link nodes
 
-We enabled Core API templating for compound children and external link nodes, meaning it's possible to use `{i18n.currentLocale}` with a viewUrl. You can find more information [here](https://github.com/SAP/luigi/pull/2288).
+We enabled Core API templating for compound children and external link nodes, meaning it's possible to use `{i18n.currentLocale}` with a viewUrl. You can find more information [here](https://github.com/luigi-project/luigi/pull/2288).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2021-11-29-release-notes.md
+++ b/blog/2021-11-29-release-notes.md
@@ -14,19 +14,19 @@ You can read about the new features in Luigi v1.19.0 in the release notes below.
 
 We replaced the CSS static value in LeftNav with a SAP Fiori 3 variable. Now, in [Luigi background themes](https://docs.luigi-project.io/docs/luigi-core-api/?section=theming), Fiori 3 variables are used instead of plain colors. To switch theme, you can replace the CSS variables stylesheet.
 
-You can find more information [here](https://github.com/SAP/luigi/pull/2369).
+You can find more information [here](https://github.com/luigi-project/luigi/pull/2369).
 
 
 #### Node category merging improvements
 
-We improved the Luigi [category property](https://docs.luigi-project.io/docs/navigation-configuration/?section=category). Now, the  first node with a "non-string" category can define the category's configuration and the category config object includes a new property `id`. If defined, it serves as the "collection key" for categorized nodes instead of the `label` property. You can find more information [here](https://github.com/SAP/luigi/pull/2352).
+We improved the Luigi [category property](https://docs.luigi-project.io/docs/navigation-configuration/?section=category). Now, the  first node with a "non-string" category can define the category's configuration and the category config object includes a new property `id`. If defined, it serves as the "collection key" for categorized nodes instead of the `label` property. You can find more information [here](https://github.com/luigi-project/luigi/pull/2352).
 
 
 #### New Core API function clearNavigationCache
 
-We introduced a new Core API function called `clearNavigationCache`. It allows you to clean nodeData cache for children resolution and titleResolver cache. For more information, see the [documentation](https://docs.luigi-project.io/docs/luigi-core-api/?section=clearnavigationcache) and [PR](https://github.com/SAP/luigi/pull/2383).
+We introduced a new Core API function called `clearNavigationCache`. It allows you to clean nodeData cache for children resolution and titleResolver cache. For more information, see the [documentation](https://docs.luigi-project.io/docs/luigi-core-api/?section=clearnavigationcache) and [PR](https://github.com/luigi-project/luigi/pull/2383).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2021-12-23-release-notes.md
+++ b/blog/2021-12-23-release-notes.md
@@ -13,7 +13,7 @@ You can read about the new features in Luigi v1.20.0 in the release notes below.
 #### New SAP icon styles support
 
 In addition to basic SAP icons, Luigi now supports the use of different SAP Icon suites like TNT and businessSuiteInAppSymbols.
-In order to use these icons, it is recommended to add `@font-face` from the [Fundamental Styles](https://sap.github.io/fundamental-styles/?path=/docs/docs-introduction--docs) project configuration to your **custom styles**. You can find more information [here](https://github.com/SAP/luigi/pull/2432).
+In order to use these icons, it is recommended to add `@font-face` from the [Fundamental Styles](https://sap.github.io/fundamental-styles/?path=/docs/docs-introduction--docs) project configuration to your **custom styles**. You can find more information [here](https://github.com/luigi-project/luigi/pull/2432).
 
 #### Global search improvements
 
@@ -25,14 +25,14 @@ You can use `globalSearchCenteredCancelButton` to define the label of the cancel
 
 #### Dynamic pathSegment for breadcrumbs and navheader
 
-As of Luigi 1.20, [dynamic pathSegments](https://docs.luigi-project.io/docs/navigation-advanced/?section=dynamic-path-parameters) are also available for breadcrumbs and navheader. You can find more information [here](https://github.com/SAP/luigi/pull/2370).
+As of Luigi 1.20, [dynamic pathSegments](https://docs.luigi-project.io/docs/navigation-advanced/?section=dynamic-path-parameters) are also available for breadcrumbs and navheader. You can find more information [here](https://github.com/luigi-project/luigi/pull/2370).
 
 #### Parameter handlers improvements
 
 In Luigi 1.20, we added an optional boolean argument called `keepBrowserHistory` to [addCoreSearchParams](https://docs.luigi-project.io/docs/luigi-client-api/?section=addcoresearchparams). It allows for the change of params without an additional browser history entry.
-We also added a function to manipulate current node parameters called [addNodeParams](https://docs.luigi-project.io/docs/luigi-client-api/?section=addnodeparams) which provides the same functionality. It gives you the option to keep browser history or not. You can find more information [here](https://github.com/SAP/luigi/pull/2409).
+We also added a function to manipulate current node parameters called [addNodeParams](https://docs.luigi-project.io/docs/luigi-client-api/?section=addnodeparams) which provides the same functionality. It gives you the option to keep browser history or not. You can find more information [here](https://github.com/luigi-project/luigi/pull/2409).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2022-04-08-release-notes.md
+++ b/blog/2022-04-08-release-notes.md
@@ -13,7 +13,7 @@ You can read about the new features in Luigi v1.21.0 in the release notes below.
 
 #### Update to Fundamental Styles v0.20.0
 
-With Luigi v.1.21 release, we updated to version 0.20.0 of Fundamental Styles. This included a small change in the `columns` attribute of our [product switcher](https://docs.luigi-project.io/docs/navigation-parameters-reference?section=product-switcher). You can set the number of columns to `auto`, which would result in 3 columns if the entities are less than or equal to 6, or 4 columns if not. You can find more information [here](https://github.com/SAP/luigi/pull/2584).
+With Luigi v.1.21 release, we updated to version 0.20.0 of Fundamental Styles. This included a small change in the `columns` attribute of our [product switcher](https://docs.luigi-project.io/docs/navigation-parameters-reference?section=product-switcher). You can set the number of columns to `auto`, which would result in 3 columns if the entities are less than or equal to 6, or 4 columns if not. You can find more information [here](https://github.com/luigi-project/luigi/pull/2584).
 
 #### Automatic navigation for modalPathParam
 
@@ -25,7 +25,7 @@ Instead of only having three default sizes for a modal, the user can now specify
 
 #### Removal of experimental flag for web components
 
-As of Luigi v.1.21.0, it is not required to include the `experimental` flag to enable web components. You can find more information [here](https://github.com/SAP/luigi/pull/2622). 
+As of Luigi v.1.21.0, it is not required to include the `experimental` flag to enable web components. You can find more information [here](https://github.com/luigi-project/luigi/pull/2622). 
 
 #### keepURL in PageNotFoundHandler
 
@@ -47,7 +47,7 @@ A new parameter `keepURL` for the [PageNotFoundHandler](https://docs.luigi-proje
 
 #### Luigi Core navigate function returns promise
 
-The [navigate](https://docs.luigi-project.io/docs/luigi-core-api/?section=navigate) function in Luigi returns a promise, which makes it easier to perform actions after changing the route. You can find more information [here](https://github.com/SAP/luigi/issues/2257). 
+The [navigate](https://docs.luigi-project.io/docs/luigi-core-api/?section=navigate) function in Luigi returns a promise, which makes it easier to perform actions after changing the route. You can find more information [here](https://github.com/luigi-project/luigi/issues/2257). 
 
 ####  New getNavFooterContainer function 
 
@@ -55,13 +55,13 @@ In Luigi v.1.21, we added a new [function](https://docs.luigi-project.io/docs/ge
 ```js
  Luigi.elements().getNavFooterContainer()
 ```
-You can find more information [here](https://github.com/SAP/luigi/pull/2488).
+You can find more information [here](https://github.com/luigi-project/luigi/pull/2488).
 
 #### Url anchor support for micro frontends
 
-Two new functions were introduced in the Luigi Client API: `getAnchor()` and `setAnchor()`. They allow the micro frontend to read and write the anchor part of the main URL to leverage in-page navigation such as scrolling. For example, if your URL is `http://example.com#myAnchor`, the function `LuigiClient.getAnchor()` would return a string `myAnchor`. You can find more information [here](https://github.com/SAP/luigi/pull/2599). 
+Two new functions were introduced in the Luigi Client API: `getAnchor()` and `setAnchor()`. They allow the micro frontend to read and write the anchor part of the main URL to leverage in-page navigation such as scrolling. For example, if your URL is `http://example.com#myAnchor`, the function `LuigiClient.getAnchor()` would return a string `myAnchor`. You can find more information [here](https://github.com/luigi-project/luigi/pull/2599). 
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2022-05-20-release-notes.md
+++ b/blog/2022-05-20-release-notes.md
@@ -13,16 +13,16 @@ You can read about the new features in Luigi v1.22.0 in the release notes below.
 
 #### Update to Fundamental Styles v0.23.0
 
-With the new release, we updated Luigi Core to version 0.23.0 of Fundamental Styles. You can read about all changes in the [release notes](https://github.com/SAP/fundamental-styles/releases/tag/v0.23.0). This update brought breaking changes and was described in the [Fundamental Library blog post](https://blogs.sap.com/2022/04/14/fundamental-library-styles-update/). You can also review the Luigi changes [here](https://github.com/SAP/luigi/pull/2698). 
+With the new release, we updated Luigi Core to version 0.23.0 of Fundamental Styles. You can read about all changes in the [release notes](https://github.com/SAP/fundamental-styles/releases/tag/v0.23.0). This update brought breaking changes and was described in the [Fundamental Library blog post](https://blogs.sap.com/2022/04/14/fundamental-library-styles-update/). You can also review the Luigi changes [here](https://github.com/luigi-project/luigi/pull/2698). 
 
 #### Disable keyboard accessibility on all elements outside drawers and modals
 
-When a drawer, modal, or confirmation modal is opened, keyboard actions outside of them are now disabled. Pressing TAB key will no longer select elements in the background that are not part of the modal/drawer. For more information, see the Luigi issues [2411](https://github.com/SAP/luigi/issues/2411) and [2690](https://github.com/SAP/luigi/issues/2690).
+When a drawer, modal, or confirmation modal is opened, keyboard actions outside of them are now disabled. Pressing TAB key will no longer select elements in the background that are not part of the modal/drawer. For more information, see the Luigi issues [2411](https://github.com/luigi-project/luigi/issues/2411) and [2690](https://github.com/luigi-project/luigi/issues/2690).
 
 #### Add functionality for allow attribute to be separated by semicolons
 
-Luigi [allowRules](https://docs.luigi-project.io/docs/general-settings/?section=allowrules) now follow the [Feature Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) convention and allow the attributes to be separated by semicolons. You can find more information [here](https://github.com/SAP/luigi/pull/2642). 
+Luigi [allowRules](https://docs.luigi-project.io/docs/general-settings/?section=allowrules) now follow the [Feature Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) convention and allow the attributes to be separated by semicolons. You can find more information [here](https://github.com/luigi-project/luigi/pull/2642). 
 
 #### Bugfixes
 
-For a full list of bugfixes, see the [GitHub release page](https://github.com/SAP/luigi/releases/tag/v1.22.0).
+For a full list of bugfixes, see the [GitHub release page](https://github.com/luigi-project/luigi/releases/tag/v1.22.0).

--- a/blog/2022-06-17-release-notes.md
+++ b/blog/2022-06-17-release-notes.md
@@ -11,20 +11,20 @@ You can read about the new features in Luigi v1.23.0 in the release notes below.
 <!-- Excerpt -->
 #### Disable keyboard accessibility for user settings dialog
 
-When the user settings dialog is opened, it is no longer possible to navigate to other UI elements outside it using the keyboard. For more information see the [pull request](https://github.com/SAP/luigi/pull/2752).
+When the user settings dialog is opened, it is no longer possible to navigate to other UI elements outside it using the keyboard. For more information see the [pull request](https://github.com/luigi-project/luigi/pull/2752).
 
 #### getCurrentRoute function
 
-We added a new `getCurrentRoute` function which belongs to the [LinkManager](https://docs.luigi-project.io/docs/luigi-client-api/?section=linkmanager) in Luigi Client. It can be used to get the Luigi route associated with the current micro frontend. The function returns a promise which resolves to a string value specifying the current Luigi route. You can find more information [here](https://github.com/SAP/luigi/issues/2724).
+We added a new `getCurrentRoute` function which belongs to the [LinkManager](https://docs.luigi-project.io/docs/luigi-client-api/?section=linkmanager) in Luigi Client. It can be used to get the Luigi route associated with the current micro frontend. The function returns a promise which resolves to a string value specifying the current Luigi route. You can find more information [here](https://github.com/luigi-project/luigi/issues/2724).
 
 #### Scalable keyboard accessibility for Language Dropdown
 
-This release brings improvements to the language dropdown within the user settings dialog. For example, it is now possible to navigate through the list of languages using the `up` and `down` arrow keys, while `Enter` selects the item.  You can find more information [here](https://github.com/SAP/luigi/issues/2565).
+This release brings improvements to the language dropdown within the user settings dialog. For example, it is now possible to navigate through the list of languages using the `up` and `down` arrow keys, while `Enter` selects the item.  You can find more information [here](https://github.com/luigi-project/luigi/issues/2565).
 
 #### Updated Luigi version in Core examples
-The [Luigi Core examples](https://github.com/SAP/luigi/tree/main/core/examples) were updated to the latest version of Luigi. The examples are now using Fundamental Styles v0.23.0, which you can learn more about [here](https://luigi-project.io/blog/2022-05-20-release-notes#update-to-fundamental-styles-v0230).
+The [Luigi Core examples](https://github.com/luigi-project/luigi/tree/main/core/examples) were updated to the latest version of Luigi. The examples are now using Fundamental Styles v0.23.0, which you can learn more about [here](https://luigi-project.io/blog/2022-05-20-release-notes#update-to-fundamental-styles-v0230).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2022-07-18-release-notes.md
+++ b/blog/2022-07-18-release-notes.md
@@ -20,8 +20,8 @@ We added a way to make the Shellbar padding responsive by using the `header.resp
 
 #### Multiple modal dialogs
 
-Luigi now allows you to open multiple modals by using the `modalSettings.keepPrevious` API function. When you set this to `true`, the previously opened modal will be kept allowing to open another model on top of it. By default, the previous modals are discarded. You can find more information in the relevant [documentation](https://docs.luigi-project.io/docs/luigi-client-api/?section=openasmodal) and [pull request](https://github.com/SAP/luigi/pull/2785). 
+Luigi now allows you to open multiple modals by using the `modalSettings.keepPrevious` API function. When you set this to `true`, the previously opened modal will be kept allowing to open another model on top of it. By default, the previous modals are discarded. You can find more information in the relevant [documentation](https://docs.luigi-project.io/docs/luigi-client-api/?section=openasmodal) and [pull request](https://github.com/luigi-project/luigi/pull/2785). 
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2022-09-30-release-notes.md
+++ b/blog/2022-09-30-release-notes.md
@@ -12,15 +12,15 @@ You can read about the new features in Luigi v1.25.0 in the release notes below.
 
 #### Ignore events from inactive iframes
 
-With the changes made in Luigi v1.25, you will have the configurable option to no longer trigger events when an iframe micro frontend is not active. For reference, see the [pull request](https://github.com/SAP/luigi/pull/2908).
+With the changes made in Luigi v1.25, you will have the configurable option to no longer trigger events when an iframe micro frontend is not active. For reference, see the [pull request](https://github.com/luigi-project/luigi/pull/2908).
 
 #### getActiveFeatureToggles in Luigi Web Components
 
-We added the function [getActiveFeatureToggleList](https://docs.luigi-project.io/docs/luigi-core-api/?section=examples-58) to the Luigi Web Components API. For more information, see the [pull request](https://github.com/SAP/luigi/pull/2893). 
+We added the function [getActiveFeatureToggleList](https://docs.luigi-project.io/docs/luigi-core-api/?section=examples-58) to the Luigi Web Components API. For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/2893). 
 
 #### Create React App Luigi Template
 
-[Create React App](https://github.com/facebook/create-react-app) is a simple way to create React apps with no build configuration. With this release, Luigi added a new template to enable you to quickly deploy React micro frontends with Luigi. You can find the template on our [GitHub repository](https://github.com/SAP/luigi/tree/main/cra-template).
+[Create React App](https://github.com/facebook/create-react-app) is a simple way to create React apps with no build configuration. With this release, Luigi added a new template to enable you to quickly deploy React micro frontends with Luigi. You can find the template on our [GitHub repository](https://github.com/luigi-project/luigi/tree/main/cra-template).
 
 #### Implement tests by using luigi mock module
 
@@ -36,8 +36,8 @@ Starting from this release, you can use the new parameter [header.disabled](http
 
 #### New js-test-application for e2e tests
 
-We introduced a new Vanilla JS test application to replace using Luigi Fiddle locally as a test application. The new test application has no default Luigi config. A test has to call the application with a specific config. For more information, see the [pull request](https://github.com/SAP/luigi/pull/2861).
+We introduced a new Vanilla JS test application to replace using Luigi Fiddle locally as a test application. The new test application has no default Luigi config. A test has to call the application with a specific config. For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/2861).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2023-01-17-release-notes.md
+++ b/blog/2023-01-17-release-notes.md
@@ -12,15 +12,15 @@ You can read about the new features in Luigi v1.26.0 in the release notes below.
 
 #### Enhanced Left Navigation Accessibility
 
-In Luigi v1.26.0, we resolved issues related to accessibility in the left side navigation. We made the collapsed-state left navigation buttons accessible via keyboard and the collapsed-state category popups closeable via the `escape` key. For reference, see the [pull request](https://github.com/SAP/luigi/pull/3094).
+In Luigi v1.26.0, we resolved issues related to accessibility in the left side navigation. We made the collapsed-state left navigation buttons accessible via keyboard and the collapsed-state category popups closeable via the `escape` key. For reference, see the [pull request](https://github.com/luigi-project/luigi/pull/3094).
 
 #### Callback Added to OpenAsModal for Core API
 
-We added the parameter `onCloseCallback` to [openAsModal](https://docs.luigi-project.io/docs/luigi-core-api/?section=openasmodal) in the Luigi Core API. The callback function is called upon closing the opened modal. For more information, see the [pull request](https://github.com/SAP/luigi/pull/3049).
+We added the parameter `onCloseCallback` to [openAsModal](https://docs.luigi-project.io/docs/luigi-core-api/?section=openasmodal) in the Luigi Core API. The callback function is called upon closing the opened modal. For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/3049).
 
 #### Luigi Client Type Declaration for Web Components
 
-In this release, we added Luigi Client type declaration for [Web Components](https://docs.luigi-project.io/docs/web-component). For more information, see the [pull request](https://github.com/SAP/luigi/pull/2963).
+In this release, we added Luigi Client type declaration for [Web Components](https://docs.luigi-project.io/docs/web-component). For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/2963).
 
 #### Alignment of StatusBadge
  
@@ -57,16 +57,16 @@ LuigiClient.linkManager().navigateToIntent('External-view')
 LuigiClient.linkManager().navigate('/#?intent=External-view')
 Luigi.navigation().navigate('/#?intent=External-view')
 ```
-See the [pull request](https://github.com/SAP/luigi/pull/2941) and [advanced scenarios](https://docs.luigi-project.io/docs/advanced-scenarios) for more information. 
+See the [pull request](https://github.com/luigi-project/luigi/pull/2941) and [advanced scenarios](https://docs.luigi-project.io/docs/advanced-scenarios) for more information. 
 
 #### LuigiElement Shadow Mode Configuration 
 
-Luigi Client's LuigiElement no longer sets the shadow mode to `closed`. Instead, there is an option to configure it as `open` or closed. See the [pull request](https://github.com/SAP/luigi/pull/2932) for more information.
+Luigi Client's LuigiElement no longer sets the shadow mode to `closed`. Instead, there is an option to configure it as `open` or closed. See the [pull request](https://github.com/luigi-project/luigi/pull/2932) for more information.
 
 #### History Handling for Modals
 
-In this release, we improved the browser history handling of [modals](https://docs.luigi-project.io/docs/navigation-parameters-reference/?section=opennodeinmodal). Due to the limitation of the `history.length` object to 50 entries in Chrome and Firefox browsers, this was changed to a `history.state` object. See the [pull request](https://github.com/SAP/luigi/pull/3072) for more information.
+In this release, we improved the browser history handling of [modals](https://docs.luigi-project.io/docs/navigation-parameters-reference/?section=opennodeinmodal). Due to the limitation of the `history.length` object to 50 entries in Chrome and Firefox browsers, this was changed to a `history.state` object. See the [pull request](https://github.com/luigi-project/luigi/pull/3072) for more information.
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2023-02-10-release-notes.md
+++ b/blog/2023-02-10-release-notes.md
@@ -22,7 +22,7 @@ Luigi v2.0 will no longer be able to support Angular versions 13 or below. The [
 
 #### Renaming GitHub branch to `main`
 
-For Luigi v2.0, we renamed our GitHub default branch from `master` to `main`. This means that if you have cloned the [Luigi repository](https://github.com/SAP/luigi), you need to switch to the `main` branch. You can use the following commands to do so:
+For Luigi v2.0, we renamed our GitHub default branch from `master` to `main`. This means that if you have cloned the [Luigi repository](https://github.com/luigi-project/luigi), you need to switch to the `main` branch. You can use the following commands to do so:
 
 ```bash
 git branch -m master main
@@ -32,5 +32,5 @@ git branch -u upstream/main main
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2023-03-30-release-notes.md
+++ b/blog/2023-03-30-release-notes.md
@@ -18,5 +18,5 @@ This new method can be used together with [setDirtyStatus](https://docs.luigi-pr
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2023-05-02-release-notes.md
+++ b/blog/2023-05-02-release-notes.md
@@ -24,9 +24,9 @@ Luigi v2.2 allows you to add a [breadcrumbs](https://developer.mozilla.org/en-US
 
 #### Prevent re-rendering of web components 
 
-In certain cases, such as when web components got a context update, they were re-rendered. We fixed this in Luigi v2.2. For more information, see the [pull request](https://github.com/SAP/luigi/pull/3226). 
+In certain cases, such as when web components got a context update, they were re-rendered. We fixed this in Luigi v2.2. For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/3226). 
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).
 

--- a/blog/2023-07-28-release-notes.md
+++ b/blog/2023-07-28-release-notes.md
@@ -13,7 +13,7 @@ You can read about the new features in Luigi v2.3 in the release notes below.
 #### Write updated modal settings to URL
 
 In this release, we added some new features to the [updateModalSettings](https://docs.luigi-project.io/docs/luigi-client-api/?section=updatemodalsettings) function. If `routing.showModalPathInUrl` is set to true, the URL will be updated with the modal settings data. With the new `addHistoryEntry` parameter, you can also add an entry in the browser history by setting it to `true`.
-You can find more information in the feature's [pull request](https://github.com/SAP/luigi/pull/3339).
+You can find more information in the feature's [pull request](https://github.com/luigi-project/luigi/pull/3339).
 
 #### Expand category by navigation
 
@@ -21,12 +21,12 @@ We added the option to expand the left-side menu by navigating to the children o
 
 #### Transfer theme variables
 
-This new Luigi feature allows you to transfer a dedicated list of CSS variables to the micro frontends. You can optionally set this in the Luigi [general settings](https://docs.luigi-project.io/docs/general-settings?section=theming) as part of the `theming` element. Additionally, you can use the method `getCSSVariables` in the [Luigi Core API](https://docs.luigi-project.io/docs/luigi-core-api?section=getcssvariables) and [Client API](https://docs.luigi-project.io/docs/luigi-client-api?section=getcssvariables). For more information, see the [pull request](https://github.com/SAP/luigi/pull/3234).
+This new Luigi feature allows you to transfer a dedicated list of CSS variables to the micro frontends. You can optionally set this in the Luigi [general settings](https://docs.luigi-project.io/docs/general-settings?section=theming) as part of the `theming` element. Additionally, you can use the method `getCSSVariables` in the [Luigi Core API](https://docs.luigi-project.io/docs/luigi-core-api?section=getcssvariables) and [Client API](https://docs.luigi-project.io/docs/luigi-client-api?section=getcssvariables). For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/3234).
 
 #### Semi-collapsible button style
 
-In Luigi 2.3, we introduced the option to define a style for the button to expand/close a semi-collapsible menu. You  can do this with the help of the new [semiCollapsibleButtonStyle](https://docs.luigi-project.io/docs/general-settings?section=semicollapsiblebuttonstyle) parameter. You can find more information in the [pull request](https://github.com/SAP/luigi/pull/3285).
+In Luigi 2.3, we introduced the option to define a style for the button to expand/close a semi-collapsible menu. You  can do this with the help of the new [semiCollapsibleButtonStyle](https://docs.luigi-project.io/docs/general-settings?section=semicollapsiblebuttonstyle) parameter. You can find more information in the [pull request](https://github.com/luigi-project/luigi/pull/3285).
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2023-08-23-release-notes.md
+++ b/blog/2023-08-23-release-notes.md
@@ -20,11 +20,11 @@ With this release, we added the possibility to use more Luigi Client functions w
 
 #### Added onLoad functionality for web components
 
-We added an onLoad functionality to web component micro frontends. An event `wc_ready` is sent when the web component is ready, which should then initialize Luigi Client. It is possible to defer this initialization using `deferLuigiClientWCInit: true`. For more information, see the [pull request](https://github.com/SAP/luigi/pull/3352).  
+We added an onLoad functionality to web component micro frontends. An event `wc_ready` is sent when the web component is ready, which should then initialize Luigi Client. It is possible to defer this initialization using `deferLuigiClientWCInit: true`. For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/3352).  
 
 #### data-testid attribute for the modal close button 
 
-In this release, we added the possibility to configure a `data-testid` attribute for the close button of a modal. The attribute can be specified via the `modalSettings` in [openAsModal](https://docs.luigi-project.io/docs/luigi-core-api/?section=openasmodal). For more information, see the [pull request](https://github.com/SAP/luigi/pull/3394). 
+In this release, we added the possibility to configure a `data-testid` attribute for the close button of a modal. The attribute can be specified via the `modalSettings` in [openAsModal](https://docs.luigi-project.io/docs/luigi-core-api/?section=openasmodal). For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/3394). 
 
 #### Removed onunload listener 
 

--- a/blog/2023-09-04-release-notes.md
+++ b/blog/2023-09-04-release-notes.md
@@ -12,12 +12,12 @@ You can read about the new features in Luigi v2.5 in the release notes below.
 
 #### Global context
 
-In Luigi v2.5, we added a new `globalContext` navigation parameter and a set of Luigi Core API functions: `setGlobalContext` and `getGlobalContext`. The global context contains key-object pairs which are inherited from all node [contexts](https://docs.luigi-project.io/docs/navigation-advanced?section=contexts). You can find more information in the [pull request](https://github.com/SAP/luigi/pull/3416). 
+In Luigi v2.5, we added a new `globalContext` navigation parameter and a set of Luigi Core API functions: `setGlobalContext` and `getGlobalContext`. The global context contains key-object pairs which are inherited from all node [contexts](https://docs.luigi-project.io/docs/navigation-advanced?section=contexts). You can find more information in the [pull request](https://github.com/luigi-project/luigi/pull/3416). 
 
 #### Return empty object for getContext 
 
-Within the [Client Support Angular](https://docs.luigi-project.io/docs/framework-support-libraries?section=angular-support-library) library, the [LuigiContextService.getContext](https://github.com/SAP/luigi/blob/main/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts#L30) function can now return an empty object if not set yet. Previously, this value could be null/undefined. You can find more information in the [pull request](https://github.com/SAP/luigi/pull/3405). 
+Within the [Client Support Angular](https://docs.luigi-project.io/docs/framework-support-libraries?section=angular-support-library) library, the [LuigiContextService.getContext](https://github.com/luigi-project/luigi/blob/main/client-frameworks-support/client-support-angular/projects/client-support-angular/src/lib/service/luigi-context.service.impl.ts#L30) function can now return an empty object if not set yet. Previously, this value could be null/undefined. You can find more information in the [pull request](https://github.com/luigi-project/luigi/pull/3405). 
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2023-09-20-release-notes.md
+++ b/blog/2023-09-20-release-notes.md
@@ -12,10 +12,10 @@ You can read about the new features in Luigi v2.6 in the release notes below.
 
 #### getUserSettings for web components
 
-In Luigi 2.6, we added the possibility to use the [getUserSettings](https://docs.luigi-project.io/docs/luigi-client-api/?section=getusersettings) function with [web components](https://docs.luigi-project.io/docs/web-component). You can find more information in the [pull request](https://github.com/SAP/luigi/pull/3414). If you have been following our previous releases, you may notice we already introduced multiple other Luigi Client functions for web components, for example in [Luigi 2.4](https://luigi-project.io/blog/2023-08-23-release-notes#luigi-client-functions-for-web-components).
+In Luigi 2.6, we added the possibility to use the [getUserSettings](https://docs.luigi-project.io/docs/luigi-client-api/?section=getusersettings) function with [web components](https://docs.luigi-project.io/docs/web-component). You can find more information in the [pull request](https://github.com/luigi-project/luigi/pull/3414). If you have been following our previous releases, you may notice we already introduced multiple other Luigi Client functions for web components, for example in [Luigi 2.4](https://luigi-project.io/blog/2023-08-23-release-notes#luigi-client-functions-for-web-components).
 
 #### Bugfixes
 
-In Luigi 2.6, we fixed an issue regarding contexts in the left-side navigation. For more information, see the [pull request](https://github.com/SAP/luigi/pull/3438). 
+In Luigi 2.6, we fixed an issue regarding contexts in the left-side navigation. For more information, see the [pull request](https://github.com/luigi-project/luigi/pull/3438). 
 
-You can also check our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md) for a full list of bugfixes in every Luigi release, including minor releases that are not listed on our blog.
+You can also check our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md) for a full list of bugfixes in every Luigi release, including minor releases that are not listed on our blog.

--- a/blog/2023-10-18-release-notes.md
+++ b/blog/2023-10-18-release-notes.md
@@ -28,4 +28,4 @@ In this release, we added the possibility to use more Luigi Client functions wit
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2023-11-14-luigi-container.md
+++ b/blog/2023-11-14-luigi-container.md
@@ -54,7 +54,7 @@ The **Luigi Compound Container** works similarly to Luigi's compound web compone
 
 #### Examples
 
-You can find a Luigi Container test application on [GitHub](https://github.com/SAP/luigi/tree/main/container/test-app). Check out the [documentation](https://docs.luigi-project.io/docs/luigi-container?section=examples) for installation instructions.
+You can find a Luigi Container test application on [GitHub](https://github.com/luigi-project/luigi/tree/main/container/test-app). Check out the [documentation](https://docs.luigi-project.io/docs/luigi-container?section=examples) for installation instructions.
 
 You can also take a look at our [Luigi Container UI5 tutorial](https://developers.sap.com/tutorials/luigi-container.html) which shows you how to install and use Luigi Container inside an UI5 app.
 

--- a/blog/2024-01-23-release-notes.md
+++ b/blog/2024-01-23-release-notes.md
@@ -18,4 +18,4 @@ In this release, we have extended the `compound web component` to support lazy l
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-02-02-luigi-container.md
+++ b/blog/2024-02-02-luigi-container.md
@@ -12,4 +12,4 @@ You can read about the new features in Luigi Container v1.1 in the release notes
 
 #### Bugfixes
 
-With this release, we prevent browser history changes from Luigi client on context update. [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.1.0).
+With this release, we prevent browser history changes from Luigi client on context update. [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.1.0).

--- a/blog/2024-02-13-release-notes.md
+++ b/blog/2024-02-13-release-notes.md
@@ -22,4 +22,4 @@ We have extended the Luigi webcomponent API with the function `setViewGroupData`
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-04-09-release-notes.md
+++ b/blog/2024-04-09-release-notes.md
@@ -22,4 +22,4 @@ We have extended the scope of Luigi testing utilities to add cypress support. Th
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-04-19-release-notes.md
+++ b/blog/2024-04-19-release-notes.md
@@ -18,4 +18,4 @@ With Luigi v2.11, clicking the category in the TabNav bar can be configured to n
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-05-03-release-notes.md
+++ b/blog/2024-05-03-release-notes.md
@@ -28,4 +28,4 @@ The console warning that appears when the favicon isn't present or is in the wro
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-05-23-release-notes.md
+++ b/blog/2024-05-23-release-notes.md
@@ -19,4 +19,4 @@ The Left Nav is now keyboard accessible when the BTP Layout is active.
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-07-10-release-notes.md
+++ b/blog/2024-07-10-release-notes.md
@@ -30,4 +30,4 @@ Fixed issue where nodes weren't rendered in the top navigation under certain con
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-07-25-luigi-container.md
+++ b/blog/2024-07-25-luigi-container.md
@@ -25,4 +25,4 @@ With this version you have the possibility to specify [sandbox](https://docs.lui
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.2.0).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.2.0).

--- a/blog/2024-08-27-luigi-container.md
+++ b/blog/2024-08-27-luigi-container.md
@@ -14,4 +14,4 @@ You can read about the new features in Luigi Container v1.3 in the release notes
 
 With this release we improved the context updating method in compound container.
 
-See our [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.3.0).
+See our [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.3.0).

--- a/blog/2024-09-27-release-notes.md
+++ b/blog/2024-09-27-release-notes.md
@@ -20,4 +20,4 @@ When experimental 'btpToolLayout' parameter is set the 'expanded' state is new d
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md#v2160-2024-09-27).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md#v2160-2024-09-27).

--- a/blog/2024-10-02-release-notes.md
+++ b/blog/2024-10-02-release-notes.md
@@ -20,4 +20,4 @@ You can read about the new features in Luigi v2.17 in the release notes below.
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md#v2170-2024-10-02).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md#v2170-2024-10-02).

--- a/blog/2024-11-06-luigi-container.md
+++ b/blog/2024-11-06-luigi-container.md
@@ -12,12 +12,12 @@ You can read about the new features in Luigi Container v1.4 in the release notes
 
 #### Custom element manifest support
 
-With this release we introduced a [custom element manifest](https://github.com/SAP/luigi/blob/main/container/public/dist/custom-elements.json) for Luigi container and Luigi compound container.
+With this release we introduced a [custom element manifest](https://github.com/luigi-project/luigi/blob/main/container/public/dist/custom-elements.json) for Luigi container and Luigi compound container.
 
 #### Luigi Compound Container improvments
 
-Furthermore we added the attributes [theme](https://github.com/SAP/luigi/blob/main/container/public/dist/custom-elements.json), [active-feature-toggle-list](https://docs.luigi-project.io/docs/luigi-compound-container-api?section=activefeaturetogglelist) and [locale](https://docs.luigi-project.io/docs/luigi-compound-container-api?section=locale) for the Luigi Compound Container.
+Furthermore we added the attributes [theme](https://github.com/luigi-project/luigi/blob/main/container/public/dist/custom-elements.json), [active-feature-toggle-list](https://docs.luigi-project.io/docs/luigi-compound-container-api?section=activefeaturetogglelist) and [locale](https://docs.luigi-project.io/docs/luigi-compound-container-api?section=locale) for the Luigi Compound Container.
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.4.0).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.4.0).

--- a/blog/2024-11-06-release-notes.md
+++ b/blog/2024-11-06-release-notes.md
@@ -20,4 +20,4 @@ There's an option to disable third party cookie check declaratively - the 'disab
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2024-11-29-luigi-container.md
+++ b/blog/2024-11-29-luigi-container.md
@@ -14,4 +14,4 @@ You can read about the new features in Luigi Container v1.5 in the release notes
 
 With this release we added the possibility for Luigi Container to [updateViewUrl](https://docs.luigi-project.io/docs/luigi-container-api?section=updateviewurl) for iframe based micro frontends.
 
-See our [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.5.0).
+See our [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.5.0).

--- a/blog/2024-12-23-release-notes.md
+++ b/blog/2024-12-23-release-notes.md
@@ -16,4 +16,4 @@ The 'getCurrentRoute' function has been added to the [Luigi Element API](https:/
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2025-02-12-luigi-container.md
+++ b/blog/2025-02-12-luigi-container.md
@@ -21,4 +21,4 @@ The `showAlert` function returns a promise for micro frontends based on web comp
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.6.0).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.6.0).

--- a/blog/2025-02-18-release-notes.md
+++ b/blog/2025-02-18-release-notes.md
@@ -22,4 +22,4 @@ Adds the option [selectionConditions](https://docs.luigi-project.io/docs/navigat
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2025-02-27-release-notes.md
+++ b/blog/2025-02-27-release-notes.md
@@ -17,4 +17,4 @@ With this release it is possible to display web component based micro frontends 
 
 #### Bugfixes
 
-For a full list of bugfixes in this release, see our [changelog](https://github.com/SAP/luigi/blob/main/CHANGELOG.md).
+For a full list of bugfixes in this release, see our [changelog](https://github.com/luigi-project/luigi/blob/main/CHANGELOG.md).

--- a/blog/2025-04-23-luigi-container.md
+++ b/blog/2025-04-23-luigi-container.md
@@ -16,4 +16,4 @@ You can read about the new features in Luigi Container v1.7 in the release notes
 With this release we added missing functions like `addCoreSearchParams`, `updateModalPathInternalNavigation`, `setDirtyStatus`, `setCurrentLocale` and `updateModalSettings` to the webcomponent client api.
 
 
-See our [changelog](https://github.com/SAP/luigi/releases/tag/container%2Fv1.7.0).
+See our [changelog](https://github.com/luigi-project/luigi/releases/tag/container%2Fv1.7.0).

--- a/client-frameworks-support/client-support-angular/README.md
+++ b/client-frameworks-support/client-support-angular/README.md
@@ -2,5 +2,5 @@
 
 ClientSupportAngular is a library that provides several features to run your Angular application inside the Luigi micro frontend framework. 
 
-You can find more information in the [main README file](https://github.com/SAP/luigi/tree/main/client-frameworks-support/client-support-angular/projects/client-support-angular#readme).
+You can find more information in the [main README file](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/client-support-angular/projects/client-support-angular#readme).
 

--- a/client-frameworks-support/client-support-angular/projects/client-support-angular/package.json
+++ b/client-frameworks-support/client-support-angular/projects/client-support-angular/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "peerDependencies": {
     "@angular/common": "20.0.0",

--- a/client-frameworks-support/client-support-ui5/README.md
+++ b/client-frameworks-support/client-support-ui5/README.md
@@ -1,6 +1,6 @@
 ## Luigi Client UI5 Support Library
 The Luigi Client UI5 support library provides several useful features to run your UI5 application inside the Luigi micro frontend framework.
-You can find more information in the [main README file](https://github.com/SAP/luigi/tree/main/client-frameworks-support/client-support-ui5/src/README.md). 
+You can find more information in the [main README file](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/client-support-ui5/src/README.md). 
 
 ## How to build
 npm run bundle

--- a/client-frameworks-support/client-support-ui5/dist/package.json
+++ b/client-frameworks-support/client-support-ui5/dist/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "keywords": [
     "luigi",

--- a/client-frameworks-support/client-support-ui5/package.json
+++ b/client-frameworks-support/client-support-ui5/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "keywords": [
     "luigi",

--- a/client-frameworks-support/testing-utilities/README.md
+++ b/client-frameworks-support/testing-utilities/README.md
@@ -1,6 +1,6 @@
 # Luigi Testing Utilities
 
-The [Luigi Testing Utilities](https://github.com/SAP/luigi/tree/main/client-frameworks-support/testing-utilities) are a set of auxiliary functions used to enhance the user experience while testing Luigi-based micro frontends. The functions abstract away Luigi-specific logic from the tester so that it is easier for them to mock and assert Luigi functionality.
+The [Luigi Testing Utilities](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/testing-utilities) are a set of auxiliary functions used to enhance the user experience while testing Luigi-based micro frontends. The functions abstract away Luigi-specific logic from the tester so that it is easier for them to mock and assert Luigi functionality.
 
 ## LuigiMockUtil
 This class contains certain utility helper functions needed when writing e2e tests with different test frameworks. You can simply import this module into you project and then use an instance of it to test micro frontend functionality.

--- a/client-frameworks-support/testing-utilities/dist/package.json
+++ b/client-frameworks-support/testing-utilities/dist/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "keywords": [
     "luigi",

--- a/client-frameworks-support/testing-utilities/package.json
+++ b/client-frameworks-support/testing-utilities/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "keywords": [
     "luigi",

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "luigi-client development version, only the public folder is being published to npm as a package",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "scripts": {
     "bundle": "npm run bundle-evergreen",

--- a/client/public/README.md
+++ b/client/public/README.md
@@ -4,8 +4,8 @@
 
 Luigi is a micro frontend orchestration framework written in Svelte. Use Luigi Client to implement micro frontends and ensure communication between the application and the micro frontend it hosts. 
 
-For details on Luigi Client, see [this](https://github.com/SAP/luigi/tree/main/client) document.
+For details on Luigi Client, see [this](https://github.com/luigi-project/luigi/tree/main/client) document.
 
-If you want to try Luigi out, see the [examples](https://github.com/SAP/luigi/tree/main/core/examples).
+If you want to try Luigi out, see the [examples](https://github.com/luigi-project/luigi/tree/main/core/examples).
 
 For documentation on Luigi Client, see [Luigi documentation](https://docs.luigi-project.io/docs/luigi-client-setup).

--- a/client/public/package.json
+++ b/client/public/package.json
@@ -5,7 +5,7 @@
   "main": "luigi-client.js",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "publishConfig": {
     "tag": "luigi-client"

--- a/container/CHANGELOG.md
+++ b/container/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 #### :rocket: Added
 
-* [#4236](https://github.com/SAP/luigi/pull/4236) Adds addCoreSearchParams fn for wc client ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4234](https://github.com/SAP/luigi/pull/4234) Adds updateModalPathInternalNavigation to WC client ([@walmazacn](https://github.com/walmazacn))
-* [#4232](https://github.com/SAP/luigi/pull/4232) Adds setDirtyStatus to WC client ([@walmazacn](https://github.com/walmazacn))
-* [#4231](https://github.com/SAP/luigi/pull/4231) Adds setCurrentLocale to WC client ([@walmazacn](https://github.com/walmazacn))
-* [#4228](https://github.com/SAP/luigi/pull/4228) Adds updateModalSettings for wc client ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4236](https://github.com/luigi-project/luigi/pull/4236) Adds addCoreSearchParams fn for wc client ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4234](https://github.com/luigi-project/luigi/pull/4234) Adds updateModalPathInternalNavigation to WC client ([@walmazacn](https://github.com/walmazacn))
+* [#4232](https://github.com/luigi-project/luigi/pull/4232) Adds setDirtyStatus to WC client ([@walmazacn](https://github.com/walmazacn))
+* [#4231](https://github.com/luigi-project/luigi/pull/4231) Adds setCurrentLocale to WC client ([@walmazacn](https://github.com/walmazacn))
+* [#4228](https://github.com/luigi-project/luigi/pull/4228) Adds updateModalSettings for wc client ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -22,14 +22,14 @@
 
 #### :rocket: Added
 
-* [#4127](https://github.com/SAP/luigi/pull/4127) rename closeAlert fn ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4115](https://github.com/SAP/luigi/pull/4115) showAlert promise for webcomponents ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4127](https://github.com/luigi-project/luigi/pull/4127) rename closeAlert fn ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4115](https://github.com/luigi-project/luigi/pull/4115) showAlert promise for webcomponents ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 #### :bug: Fixed
 
-* [#4133](https://github.com/SAP/luigi/pull/4133) Missing context properties ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4132](https://github.com/SAP/luigi/pull/4132) Container iframe get node params function missing ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#4106](https://github.com/SAP/luigi/pull/4106) Fix: dismissKey optional in closeAlert ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4133](https://github.com/luigi-project/luigi/pull/4133) Missing context properties ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4132](https://github.com/luigi-project/luigi/pull/4132) Container iframe get node params function missing ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#4106](https://github.com/luigi-project/luigi/pull/4106) Fix: dismissKey optional in closeAlert ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
 
@@ -39,7 +39,7 @@
 
 #### :rocket: Added
 
-* [#4031](https://github.com/SAP/luigi/pull/4031) Adds possibility to change route/viewUrl in iframe based mfe ([@walmazacn](https://github.com/walmazacn))
+* [#4031](https://github.com/luigi-project/luigi/pull/4031) Adds possibility to change route/viewUrl in iframe based mfe ([@walmazacn](https://github.com/walmazacn))
 
 
 
@@ -47,15 +47,15 @@
 
 #### :rocket: Added
 
-* [#3985](https://github.com/SAP/luigi/pull/3985) Add custom elements manifest for Luigi(Compound)Container ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3936](https://github.com/SAP/luigi/pull/3936) Adds theme property for compound container ([@walmazacn](https://github.com/walmazacn))
-* [#3934](https://github.com/SAP/luigi/pull/3934) Adds node params to compound container typings ([@walmazacn](https://github.com/walmazacn))
-* [#3937](https://github.com/SAP/luigi/pull/3937) Adds activeFeatureToggleList property to LuigiCompoundContainer ([@walmazacn](https://github.com/walmazacn))
-* [#3935](https://github.com/SAP/luigi/pull/3935) Adds locale property to Luigi Compound Container ([@ndricimrr](https://github.com/ndricimrr))
+* [#3985](https://github.com/luigi-project/luigi/pull/3985) Add custom elements manifest for Luigi(Compound)Container ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3936](https://github.com/luigi-project/luigi/pull/3936) Adds theme property for compound container ([@walmazacn](https://github.com/walmazacn))
+* [#3934](https://github.com/luigi-project/luigi/pull/3934) Adds node params to compound container typings ([@walmazacn](https://github.com/walmazacn))
+* [#3937](https://github.com/luigi-project/luigi/pull/3937) Adds activeFeatureToggleList property to LuigiCompoundContainer ([@walmazacn](https://github.com/walmazacn))
+* [#3935](https://github.com/luigi-project/luigi/pull/3935) Adds locale property to Luigi Compound Container ([@ndricimrr](https://github.com/ndricimrr))
 
 #### :bug: Fixed
 
-* [#3988](https://github.com/SAP/luigi/pull/3988) fix wrong msg target resolution ([@hardl](https://github.com/hardl))
+* [#3988](https://github.com/luigi-project/luigi/pull/3988) fix wrong msg target resolution ([@hardl](https://github.com/hardl))
 
 
 
@@ -64,22 +64,22 @@
 
 #### :rocket: Added
 
-* [#3831](https://github.com/SAP/luigi/pull/3831) Improves context updating method ([@walmazacn](https://github.com/walmazacn))
+* [#3831](https://github.com/luigi-project/luigi/pull/3831) Improves context updating method ([@walmazacn](https://github.com/walmazacn))
 
 
 
 ## [v1.2.0] (2024-07-25)
 
-* [#3797](https://github.com/SAP/luigi/pull/3797) Adds navigateToIntent to wc client api ([@walmazacn](https://github.com/walmazacn))
-* [#3785](https://github.com/SAP/luigi/pull/3785) Add getToken function support to Luigi Container ([@ndricimrr](https://github.com/ndricimrr))
-* [#3780](https://github.com/SAP/luigi/pull/3780) Add getCurrentRoute function support to Luigi Container ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3697](https://github.com/SAP/luigi/pull/3697) Light dom container - no-shadow option for Luigi Container ([@hardl](https://github.com/hardl))
-* [#3695](https://github.com/SAP/luigi/pull/3695) Value validation for webcomponent attribute ([@VincentUllal](https://github.com/VincentUllal))
-* [#3650](https://github.com/SAP/luigi/pull/3650) Specify iframe sandbox and allow rules ([@JohannesDoberer](https://github.com/JohannesDoberer))
-* [#3643](https://github.com/SAP/luigi/pull/3643) Align Luigi Container wc clientAPI with core ([@ndricimrr](https://github.com/ndricimrr))
+* [#3797](https://github.com/luigi-project/luigi/pull/3797) Adds navigateToIntent to wc client api ([@walmazacn](https://github.com/walmazacn))
+* [#3785](https://github.com/luigi-project/luigi/pull/3785) Add getToken function support to Luigi Container ([@ndricimrr](https://github.com/ndricimrr))
+* [#3780](https://github.com/luigi-project/luigi/pull/3780) Add getCurrentRoute function support to Luigi Container ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3697](https://github.com/luigi-project/luigi/pull/3697) Light dom container - no-shadow option for Luigi Container ([@hardl](https://github.com/hardl))
+* [#3695](https://github.com/luigi-project/luigi/pull/3695) Value validation for webcomponent attribute ([@VincentUllal](https://github.com/VincentUllal))
+* [#3650](https://github.com/luigi-project/luigi/pull/3650) Specify iframe sandbox and allow rules ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3643](https://github.com/luigi-project/luigi/pull/3643) Align Luigi Container wc clientAPI with core ([@ndricimrr](https://github.com/ndricimrr))
 
 #### :bug: Fixed
-* [#3742](https://github.com/SAP/luigi/pull/3742) Fixes show confirmation modal method ([@walmazacn](https://github.com/walmazacn))
+* [#3742](https://github.com/luigi-project/luigi/pull/3742) Fixes show confirmation modal method ([@walmazacn](https://github.com/walmazacn))
 
 
 
@@ -87,13 +87,13 @@
 ## [v1.1.0] (2024-02-02)
 
 #### :bug: Fixed
-* [#3600](https://github.com/SAP/luigi/pull/3600) Avoid browser history change from luigi client on context update ([@JohannesDoberer](https://github.com/JohannesDoberer))
+* [#3600](https://github.com/luigi-project/luigi/pull/3600) Avoid browser history change from luigi client on context update ([@JohannesDoberer](https://github.com/JohannesDoberer))
 
 
-[v1.1.0]: https://github.com/SAP/luigi/compare/container/v1.0.0...container/v1.1.0
-[v1.2.0]: https://github.com/SAP/luigi/compare/container/v1.1.0...container/v1.2.0
-[v1.3.0]: https://github.com/SAP/luigi/compare/container/v1.2.0...container/v1.3.0
-[v1.4.0]: https://github.com/SAP/luigi/compare/container/v1.3.0...container/v1.4.0
-[v1.5.0]: https://github.com/SAP/luigi/compare/container/v1.4.0...container/v1.5.0
-[v1.6.0]: https://github.com/SAP/luigi/compare/container/v1.5.0...container/v1.6.0
-[v1.7.0]: https://github.com/SAP/luigi/compare/container/v1.6.0...container/v1.7.0
+[v1.1.0]: https://github.com/luigi-project/luigi/compare/container/v1.0.0...container/v1.1.0
+[v1.2.0]: https://github.com/luigi-project/luigi/compare/container/v1.1.0...container/v1.2.0
+[v1.3.0]: https://github.com/luigi-project/luigi/compare/container/v1.2.0...container/v1.3.0
+[v1.4.0]: https://github.com/luigi-project/luigi/compare/container/v1.3.0...container/v1.4.0
+[v1.5.0]: https://github.com/luigi-project/luigi/compare/container/v1.4.0...container/v1.5.0
+[v1.6.0]: https://github.com/luigi-project/luigi/compare/container/v1.5.0...container/v1.6.0
+[v1.7.0]: https://github.com/luigi-project/luigi/compare/container/v1.6.0...container/v1.7.0

--- a/container/README.md
+++ b/container/README.md
@@ -28,7 +28,7 @@ You can now use the Luigi container as follows anywhere in your application:
         context='{"label": "Calendar"}'>
     </luigi-container>
 ```
-You can find simple examples that use [webcomponents](https://github.com/SAP/luigi/tree/main/container/examples/container-wc) and [iframes](https://github.com/SAP/luigi/tree/main/container/examples/container-iframe).
+You can find simple examples that use [webcomponents](https://github.com/luigi-project/luigi/tree/main/container/examples/container-wc) and [iframes](https://github.com/luigi-project/luigi/tree/main/container/examples/container-iframe).
 
 4. In a similar way you can use the Luigi **compound container** to insert multiple microfrontends as follows:
 
@@ -38,7 +38,7 @@ You can find simple examples that use [webcomponents](https://github.com/SAP/lui
         compoundConfig = { your config here }>
     </luigi-compound-container>
 ```
-An example can be found at [./examples/compound-container/index.html](https://github.com/SAP/luigi/tree/main/container/examples/compound-container).
+An example can be found at [./examples/compound-container/index.html](https://github.com/luigi-project/luigi/tree/main/container/examples/compound-container).
 
 ## Code coverage
 It is possible to get code coverage stats for both unit and e2e tests. In the first step trigger unit tests by running the following commands:

--- a/container/public/dist/custom-elements.json
+++ b/container/public/dist/custom-elements.json
@@ -236,14 +236,14 @@
             },
             {
               "name": "navigation-request",
-              "description": "Event fired when a navigation has been requested by the micro frontend.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload} @type {NavigationRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, link: '/test/route', nodeParams: {} }",
+              "description": "Event fired when a navigation has been requested by the micro frontend.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload} @type {NavigationRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, link: '/test/route', nodeParams: {} }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "show-alert-request",
-              "description": "Event fired when the micro frontend requests to show an alert.  Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert).  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload} @type {AlertRequestPayload} @example { text: 'Custom alert message', type: 'info', links: { goToHome: { text: 'Homepage', url: '/overview' }, goToOtherProject: { text: 'Other project', url: '/projects/pr2' }, relativePath: { text: 'Hide side nav', url: 'hideSideNav' }, neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' } }, closeAfter: 3000 }",
+              "description": "Event fired when the micro frontend requests to show an alert.  Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert).  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload} @type {AlertRequestPayload} @example { text: 'Custom alert message', type: 'info', links: { goToHome: { text: 'Homepage', url: '/overview' }, goToOtherProject: { text: 'Other project', url: '/projects/pr2' }, relativePath: { text: 'Hide side nav', url: 'hideSideNav' }, neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' } }, closeAfter: 3000 }",
               "type": {
                 "text": "Event"
               }
@@ -257,21 +257,21 @@
             },
             {
               "name": "add-search-params-request",
-              "description": "Event fired when the micro frontend requests the addition of search parameters to the URL.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
+              "description": "Event fired when the micro frontend requests the addition of search parameters to the URL.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "add-node-params-request",
-              "description": "Event fired when the micro frontend requests the addition of node parameters to the URL.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
+              "description": "Event fired when the micro frontend requests the addition of node parameters to the URL.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "show-confirmation-modal-request",
-              "description": "Event fired when the micro frontend requests to show a confirmation modal.  Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal).  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload} @type {ConfirmationModalRequestPayload} @example { header: 'Confirmation', body: 'Are you sure you want to do this?', buttonConfirm: 'Yes', buttonDismiss: 'No' }",
+              "description": "Event fired when the micro frontend requests to show a confirmation modal.  Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal).  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload} @type {ConfirmationModalRequestPayload} @example { header: 'Confirmation', body: 'Are you sure you want to do this?', buttonConfirm: 'Yes', buttonDismiss: 'No' }",
               "type": {
                 "text": "Event"
               }
@@ -327,7 +327,7 @@
             },
             {
               "name": "get-current-route-request",
-              "description": "Event fired when the micro frontend requests the current app route.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload} @type {CurrentRouteRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, nodeParams: {} }",
+              "description": "Event fired when the micro frontend requests the current app route.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload} @type {CurrentRouteRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, nodeParams: {} }",
               "type": {
                 "text": "Event"
               }
@@ -341,14 +341,14 @@
             },
             {
               "name": "update-modal-path-data-request",
-              "description": "Event fired when the micro frontend requests to update the modal path parameters.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload} @type {ModalPathDataRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, history: true, link: '/test/route', modal: { title: 'Some modal' }, nodeParams: {} }",
+              "description": "Event fired when the micro frontend requests to update the modal path parameters.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload} @type {ModalPathDataRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, history: true, link: '/test/route', modal: { title: 'Some modal' }, nodeParams: {} }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "update-modal-settings-request",
-              "description": "Event fired when the micro frontend requests to update the modal settings.  Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings).  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload} @type {ModalSettingsRequestPayload} @example { addHistoryEntry: true, updatedModalSettings: {} }",
+              "description": "Event fired when the micro frontend requests to update the modal settings.  Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings).  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload} @type {ModalSettingsRequestPayload} @example { addHistoryEntry: true, updatedModalSettings: {} }",
               "type": {
                 "text": "Event"
               }
@@ -607,14 +607,14 @@
             },
             {
               "name": "navigation-request",
-              "description": "Event fired when a navigation has been requested by the micro frontend.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload} @type {NavigationRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, link: '/test/route', nodeParams: {} }",
+              "description": "Event fired when a navigation has been requested by the micro frontend.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload} @type {NavigationRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, link: '/test/route', nodeParams: {} }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "show-alert-request",
-              "description": "Event fired when the micro frontend requests to show an alert.  Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert).  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload} @type {AlertRequestPayload} @example { text: 'Custom alert message', type: 'info', links: { goToHome: { text: 'Homepage', url: '/overview' }, goToOtherProject: { text: 'Other project', url: '/projects/pr2' }, relativePath: { text: 'Hide side nav', url: 'hideSideNav' }, neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' } }, closeAfter: 3000 }",
+              "description": "Event fired when the micro frontend requests to show an alert.  Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert).  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload} @type {AlertRequestPayload} @example { text: 'Custom alert message', type: 'info', links: { goToHome: { text: 'Homepage', url: '/overview' }, goToOtherProject: { text: 'Other project', url: '/projects/pr2' }, relativePath: { text: 'Hide side nav', url: 'hideSideNav' }, neverShowItAgain: { text: 'Never show it again', dismissKey: 'neverShowItAgain' } }, closeAfter: 3000 }",
               "type": {
                 "text": "Event"
               }
@@ -628,21 +628,21 @@
             },
             {
               "name": "add-search-params-request",
-              "description": "Event fired when the micro frontend requests the addition of search parameters to the URL.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
+              "description": "Event fired when the micro frontend requests the addition of search parameters to the URL.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "add-node-params-request",
-              "description": "Event fired when the micro frontend requests the addition of node parameters to the URL.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
+              "description": "Event fired when the micro frontend requests the addition of node parameters to the URL.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload} @type {ParamsRequestPayload} @example { data: {}, keepBrowserHistory: false }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "show-confirmation-modal-request",
-              "description": "Event fired when the micro frontend requests to show a confirmation modal.  Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal).  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload} @type {ConfirmationModalRequestPayload} @example { header: 'Confirmation', body: 'Are you sure you want to do this?', buttonConfirm: 'Yes', buttonDismiss: 'No' }",
+              "description": "Event fired when the micro frontend requests to show a confirmation modal.  Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal).  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload} @type {ConfirmationModalRequestPayload} @example { header: 'Confirmation', body: 'Are you sure you want to do this?', buttonConfirm: 'Yes', buttonDismiss: 'No' }",
               "type": {
                 "text": "Event"
               }
@@ -698,7 +698,7 @@
             },
             {
               "name": "get-current-route-request",
-              "description": "Event fired when the micro frontend requests the current app route.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload} @type {CurrentRouteRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, nodeParams: {} }",
+              "description": "Event fired when the micro frontend requests the current app route.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload} @type {CurrentRouteRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, nodeParams: {} }",
               "type": {
                 "text": "Event"
               }
@@ -712,14 +712,14 @@
             },
             {
               "name": "update-modal-path-data-request",
-              "description": "Event fired when the micro frontend requests to update the modal path parameters.  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload} @type {ModalPathDataRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, history: true, link: '/test/route', modal: { title: 'Some modal' }, nodeParams: {} }",
+              "description": "Event fired when the micro frontend requests to update the modal path parameters.  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload} @type {ModalPathDataRequestPayload} @example { fromClosestContext: false, fromContext: null, fromParent: true, fromVirtualTreeRoot: false, history: true, link: '/test/route', modal: { title: 'Some modal' }, nodeParams: {} }",
               "type": {
                 "text": "Event"
               }
             },
             {
               "name": "update-modal-settings-request",
-              "description": "Event fired when the micro frontend requests to update the modal settings.  Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings).  Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload} @type {ModalSettingsRequestPayload} @example { addHistoryEntry: true, updatedModalSettings: {} }",
+              "description": "Event fired when the micro frontend requests to update the modal settings.  Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings).  Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload} @type {ModalSettingsRequestPayload} @example { addHistoryEntry: true, updatedModalSettings: {} }",
               "type": {
                 "text": "Event"
               }

--- a/container/public/package.json
+++ b/container/public/package.json
@@ -6,7 +6,7 @@
     "types": "index.d.ts",
     "repository": {
         "type": "git",
-        "url": "ssh://github.com/SAP/luigi.git"
+        "url": "ssh://github.com/luigi-project/luigi.git"
     },
     "customElements": "./dist/custom-elements.json",
     "publishConfig": {

--- a/container/release-cli.js
+++ b/container/release-cli.js
@@ -156,7 +156,7 @@ async function prepareRelease() {
       const changelogPath = './CHANGELOG.md';
 
       //Add compare link to the end of the file
-      const lastline = `\n[v${version}]: https://github.com/SAP/luigi/compare/${lastContainerRelease.tag_name}...container/v${version}`;
+      const lastline = `\n[v${version}]: https://github.com/luigi-project/luigi/compare/${lastContainerRelease.tag_name}...container/v${version}`;
 
       //read file before append last line to file, otherwise it will not be written
       fs.readFileSync(changelogPath, 'utf8');

--- a/container/src/constants/communication.ts
+++ b/container/src/constants/communication.ts
@@ -37,7 +37,7 @@ export namespace Events {
 
   /**
    * Event fired when a navigation has been requested by the micro frontend. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload}
    * @type {NavigationRequestPayload}
    * @example
    * {
@@ -57,7 +57,7 @@ export namespace Events {
   /**
    * Event fired when the micro frontend requests to show an alert. <br>
    * Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert). <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload}
    * @type {AlertRequestPayload}
    * @example
    * {
@@ -95,7 +95,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests the addition of search parameters to the URL. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
    * @type {ParamsRequestPayload}
    * @example
    * {
@@ -110,7 +110,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests the addition of node parameters to the URL. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
    * @type {ParamsRequestPayload}
    * @example
    * {
@@ -126,7 +126,7 @@ export namespace Events {
   /**
    * Event fired when the micro frontend requests to show a confirmation modal. <br>
    * Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal). <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload}
    * @type {ConfirmationModalRequestPayload}
    * @example
    * {
@@ -223,7 +223,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests the current app route. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload}
    * @type {CurrentRouteRequestPayload}
    * @example
    * {
@@ -250,7 +250,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests to update the modal path parameters. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload}
    * @type {ModalPathDataRequestPayload}
    * @example
    * {
@@ -272,7 +272,7 @@ export namespace Events {
   /**
    * Event fired when the micro frontend requests to update the modal settings. <br>
    * Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings). <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload}
    * @type {ModalSettingsRequestPayload}
    * @example
    * {

--- a/container/typings/constants/events.d.ts
+++ b/container/typings/constants/events.d.ts
@@ -37,7 +37,7 @@ export namespace Events {
 
   /**
    * Event fired when a navigation has been requested by the micro frontend. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|NavigationRequestPayload}
    * @type {NavigationRequestPayload}
    * @example
    * {
@@ -57,7 +57,7 @@ export namespace Events {
   /**
    * Event fired when the micro frontend requests to show an alert. <br>
    * Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert). <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|AlertRequestPayload}
    * @type {AlertRequestPayload}
    * @example
    * {
@@ -95,7 +95,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests the addition of search parameters to the URL. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
    * @type {ParamsRequestPayload}
    * @example
    * {
@@ -110,7 +110,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests the addition of node parameters to the URL. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ParamsRequestPayload}
    * @type {ParamsRequestPayload}
    * @example
    * {
@@ -126,7 +126,7 @@ export namespace Events {
   /**
    * Event fired when the micro frontend requests to show a confirmation modal. <br>
    * Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal). <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ConfirmationModalRequestPayload}
    * @type {ConfirmationModalRequestPayload}
    * @example
    * {
@@ -223,7 +223,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests the current app route. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|CurrentRouteRequestPayload}
    * @type {CurrentRouteRequestPayload}
    * @example
    * {
@@ -250,7 +250,7 @@ export namespace Events {
 
   /**
    * Event fired when the micro frontend requests to update the modal path parameters. <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalPathDataRequestPayload}
    * @type {ModalPathDataRequestPayload}
    * @example
    * {
@@ -272,7 +272,7 @@ export namespace Events {
   /**
    * Event fired when the micro frontend requests to update the modal settings. <br>
    * Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings). <br><br>
-   * Payload: {@link https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload}
+   * Payload: {@link https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts|ModalSettingsRequestPayload}
    * @type {ModalSettingsRequestPayload}
    * @example
    * {

--- a/core/package.json
+++ b/core/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "engines": {
     "node": ">=18.19.1"

--- a/core/public_root/README.md
+++ b/core/public_root/README.md
@@ -4,8 +4,8 @@
 
 Luigi is a micro frontend orchestration framework written in Svelte. Use Luigi Core to implement the core application, and Luigi Client to ensure communication between the application and the micro frontend it hosts. 
 
-For details on Luigi Core, see [this](https://github.com/SAP/luigi/tree/main/core) document.
+For details on Luigi Core, see [this](https://github.com/luigi-project/luigi/tree/main/core) document.
 
-If you want to try Luigi out, see the [examples](https://github.com/SAP/luigi/tree/main/core/examples).
+If you want to try Luigi out, see the [examples](https://github.com/luigi-project/luigi/tree/main/core/examples).
 
 For documentation on Luigi Core, see [Luigi documentation](https://docs.luigi-project.io).

--- a/core/public_root/package.json
+++ b/core/public_root/package.json
@@ -5,7 +5,7 @@
   "main": "luigi.js",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "publishConfig": {
     "tag": "luigi"

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -1101,7 +1101,7 @@ describe('Routing', function() {
     });
 
     it('calls proper function if item is an external link with url', () => {
-      const url = 'https://github.com/SAP/luigi';
+      const url = 'https://github.com/luigi-project/luigi';
       Routing.navigateToLink({ externalLink: { url } });
       sinon.assert.calledOnce(Routing.navigateToExternalLink);
       sinon.assert.calledWithExactly(Routing.navigateToExternalLink, { url });

--- a/core/test/utilities/helpers/escaping-helpers.spec.js
+++ b/core/test/utilities/helpers/escaping-helpers.spec.js
@@ -98,12 +98,12 @@ describe('Escaping-helpers', () => {
       const links = {
         issues: {
           text: 'Issues',
-          url: `http://github.com/SAP/luigi/issues`,
+          url: `http://github.com/luigi-project/luigi/issues`,
           dismissKey: 'goToHome'
         },
         pulls: {
           text: 'Pulls',
-          url: `http://github.com/SAP/luigi/pulls`
+          url: `http://github.com/luigi-project/luigi/pulls`
         }
       };
       const uniqueID = 1234567890;
@@ -119,12 +119,12 @@ describe('Escaping-helpers', () => {
           {
             dismissKey: 'goToHome-sanitizeHtml',
             elemId: '_luigi_alert_1234567890_link_issues-sanitizeParam',
-            url: 'http://github.com/SAP/luigi/issues-sanitizeHtml'
+            url: 'http://github.com/luigi-project/luigi/issues-sanitizeHtml'
           },
           {
             dismissKey: undefined,
             elemId: '_luigi_alert_1234567890_link_pulls-sanitizeParam',
-            url: 'http://github.com/SAP/luigi/pulls-sanitizeHtml'
+            url: 'http://github.com/luigi-project/luigi/pulls-sanitizeHtml'
           }
         ]
       };

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,4 +50,4 @@ Check the Luigi [application examples](../core/examples) for an in-depth�
 
 ## Development
 
-Read the [development and code formatting guidelines](https://github.com/SAP/luigi#development) if you are interested in contributing.
+Read the [development and code formatting guidelines](https://github.com/luigi-project/luigi#development) if you are interested in contributing.

--- a/docs/application-setup.md
+++ b/docs/application-setup.md
@@ -19,7 +19,7 @@ meta -->
 <!-- add-attribute:class:warning -->
 > **NOTE:** The setup scripts are a quick and easy way to create a running Luigi Core app and micro frontend hosted by the same webserver, but they don't represent a real-life scenario where the different pieces are distributed.
 
-This document shows you how to quickly set up a Luigi web application by installing some of our [examples](https://github.com/SAP/luigi/tree/main/core/examples). They can be a good way to learn about setting up a Luigi project, but how you add Luigi to your application will depend on the framework you use and the application itself. 
+This document shows you how to quickly set up a Luigi web application by installing some of our [examples](https://github.com/luigi-project/luigi/tree/main/core/examples). They can be a good way to learn about setting up a Luigi project, but how you add Luigi to your application will depend on the framework you use and the application itself. 
 
 In the quick setup examples on this page, you can use a single **installer** script which executes these steps: 
 * Add Luigi's `npm` packages (e.g. for Luigi [Core](https://www.npmjs.com/package/@luigi-project/core)/[Client](https://www.npmjs.com/package/@luigi-project/client)) to your project dependencies.
@@ -45,7 +45,7 @@ You can see how to quickly start an Angular Luigi application in this video:
 1. Use the following installer to create a directory for your application, install Luigi, make assets available, and start your local server:
 
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/no-framework.sh)
+bash <(curl -s https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/no-framework.sh)
 ```
 or execute these commands manually to get the same result:
 <!-- accordion:start -->
@@ -54,7 +54,7 @@ or execute these commands manually to get the same result:
 mkdir my-new-app && cd my-new-app
 
 # Download the package.json
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/package.json > package.json
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/package.json > package.json
 
 
 # Install packages and create folder structure
@@ -63,12 +63,12 @@ mkdir -p public/assets
 mkdir -p src/luigi-config
 
 # download assets from core/examples folder
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/favicon.ico > public/favicon.ico
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/logo.png > public/logo.png
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/luigi-config.js > public/luigi-config.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/views/home.html > public/views/home.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/views/sample1.html > public/views/sample1.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/favicon.ico > public/favicon.ico
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/logo.png > public/logo.png
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/luigi-config.js > public/luigi-config.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/views/home.html > public/views/home.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/views/sample1.html > public/views/sample1.html
 
 echo "Running server with command: npm run start"
 npm run start
@@ -89,7 +89,7 @@ npm run start
 2. Use the installer to create your application, install Luigi, make assets available, and serve your application:
 
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/angular.sh)
+bash <(curl -s https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/angular.sh)
 ```
 or execute these commands manually to get the same result:
 <!-- accordion:start -->
@@ -106,9 +106,9 @@ mkdir -p src/luigi-config
 mv src/index.html src/angular.html
 
 # download assets
-curl https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/assets/index.html > src/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/assets/luigi-config.es6.js > src/luigi-config/luigi-config.es6.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/assets/basicMicroFrontend.html > src/assets/basicMicroFrontend.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/assets/index.html > src/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/assets/luigi-config.es6.js > src/luigi-config/luigi-config.es6.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/assets/basicMicroFrontend.html > src/assets/basicMicroFrontend.html
 
 # string replacements in some files
 sed 's#"src/index.html"#"src/angular.html"#g' angular.json > tmp.json && mv tmp.json angular.json
@@ -135,7 +135,7 @@ npm run start
 1. Use the installer to create a directory for your application, install Luigi, make assets available, and start your local server:
 
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/openui5.sh)
+bash <(curl -s https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/openui5.sh)
 ```
 or execute these commands manually to get the same result:
 
@@ -146,7 +146,7 @@ mkdir my-ui5-app && cd my-ui5-app
 echo "Creating folders and downloading example assets"
 mkdir -p ./webapp/home ./webapp/libs ./webapp/sample1 ./webapp/sample2 ./webapp/i18n
 
-export UI5EX_REPO_URL="https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-openui5"
+export UI5EX_REPO_URL="https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-openui5"
 
 curl --silent $UI5EX_REPO_URL/webapp/sample2/Sample2.view.xml > ./webapp/sample2/Sample2.view.xml
 curl --silent $UI5EX_REPO_URL/webapp/sample2/sample2.html > ./webapp/sample2/sample2.html
@@ -196,7 +196,7 @@ npm install -g @vue/cli
 
 2. Use the installer to create your application, install Luigi, make assets available, and serve your application:
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/vue.sh)
+bash <(curl -s https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/vue.sh)
 ```
 or execute these commands manually to get the same result:
 
@@ -208,7 +208,7 @@ or execute these commands manually to get the same result:
 vue create -d my-vue-app && cd my-vue-app
 
 # install dependencies
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/package.json > package.json
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/package.json > package.json
 npm i
 
 mkdir -p src/views src/router 
@@ -255,17 +255,17 @@ module.exports = {
 
 
 # fetch assets from vue example
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/public/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/public/sampleapp.html > public/sampleapp.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/app.vue > src/app.vue
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/main.js > src/main.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/public/luigi-config.js > public/luigi-config.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/public/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/public/sampleapp.html > public/sampleapp.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/app.vue > src/app.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/main.js > src/main.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/public/luigi-config.js > public/luigi-config.js
 
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/router/index.js > src/router/index.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/router/index.js > src/router/index.js
 
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/views/home.vue > src/views/home.vue
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/views/sample1.vue > src/views/sample1.vue
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/views/sample2.vue > src/views/sample2.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/views/home.vue > src/views/home.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/views/sample1.vue > src/views/sample1.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/views/sample2.vue > src/views/sample2.vue
 
 # generic assets
 
@@ -280,7 +280,7 @@ npm run serve
 
 1. Use the installer to create your application, install Luigi, make assets available, and serve your application:
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/react.sh)
+bash <(curl -s https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/react.sh)
 ```
 or execute these commands manually to get the same result:
 
@@ -333,20 +333,20 @@ echo '{
 
 # downloads
 mkdir -p src/luigi-config
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/sampleapp.html > public/sampleapp.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/luigi-config.js > src/luigi-config/luigi-config.es6.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/sampleapp.html > public/sampleapp.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/luigi-config.js > src/luigi-config/luigi-config.es6.js
 
 
 # add index.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/index.js > src/index.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/index.css > src/index.css
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/index.js > src/index.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/index.css > src/index.css
 
 # add views
 mkdir src/views
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/views/home.js > src/views/home.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/views/sample1.js > src/views/sample1.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/views/sample2.js > src/views/sample2.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/views/home.js > src/views/home.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/views/sample1.js > src/views/sample1.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/views/sample2.js > src/views/sample2.js
 
 npm i
 npm run buildConfig

--- a/docs/authorization-configuration.md
+++ b/docs/authorization-configuration.md
@@ -148,7 +148,7 @@ auth: {
 
 The OpenID Connect configuration allows you to specify the **automaticSilentRenew** option. When set to `true`, Luigi attempts to automatically renew the token in the background before it expires. Be aware that this mechanism requires the browser to support [third-party cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#Third-party_cookies).
 
-To detect whether the user's browser supports the mechanism, use the script in the [`third-party-cookies`](https://github.com/SAP/luigi/tree/main/core/third-party-cookies) catalog. Deploy this file on a domain different from your main application's and set **thirdPartyCookiesScriptLocation** to the `init.html` file. During initialization, Luigi detects the cookies support and produces a warning in the console if cookies are disabled in the user's browser.
+To detect whether the user's browser supports the mechanism, use the script in the [`third-party-cookies`](https://github.com/luigi-project/luigi/tree/main/core/third-party-cookies) catalog. Deploy this file on a domain different from your main application's and set **thirdPartyCookiesScriptLocation** to the `init.html` file. During initialization, Luigi detects the cookies support and produces a warning in the console if cookies are disabled in the user's browser.
 
 When Luigi fails to renew the token and then logs the user out, it adds the `?reason=tokenExpired&thirdPartyCookies=[VALUE]` query parameters to the logout page redirect URL. Luigi replaces **[VALUE]**  with one of these options:
 - `disabled` means that third party cookies are disabled.
@@ -304,7 +304,7 @@ Luigi.setConfig({
 ​
 After authorization is successful on the authorization provider's side, it redirects back to `Luigi callback.html` **redirect_uri**. The provider verifies the authorization data, saves it in  **localStorage** for Luigi, and redirects to the Luigi main page.
 
-You can use the Luigi implementations of [OAuth2](https://github.com/SAP/luigi/blob/main/plugins/auth/src/auth-oauth2/index.js) and [OpenID Connect](https://github.com/SAP/luigi/blob/main/plugins/auth/src/auth-oidc-pkce/index.js) (or older [OIDC plugin](https://github.com/SAP/luigi/blob/main/plugins/auth/src/auth-oidc/index.js) for implict flow) as examples when creating your own authorization provider.
+You can use the Luigi implementations of [OAuth2](https://github.com/luigi-project/luigi/blob/main/plugins/auth/src/auth-oauth2/index.js) and [OpenID Connect](https://github.com/luigi-project/luigi/blob/main/plugins/auth/src/auth-oidc-pkce/index.js) (or older [OIDC plugin](https://github.com/luigi-project/luigi/blob/main/plugins/auth/src/auth-oidc/index.js) for implict flow) as examples when creating your own authorization provider.
 
 <!-- add-attribute:class:warning -->
 >**NOTE:** Read more about authorization helpers in the [Core API: AuthorizationStore](luigi-core-api.md#AuthorizationStore) section.

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -62,10 +62,10 @@ For Luigi Client to process the message, add and remove message listeners as des
 In the `communication:` section of the Luigi config, you can add the `skipEventsWhenInactive` parameter in order to ignore events normally sent from Luigi Client to Luigi Core when an iframe/micro frontend is not currently selected or active. 
 
 For example, you can ignore any of these events (or others, as needed):
-- [luigi.navigation.open](https://github.com/SAP/luigi/blob/main/client/src/linkManager.js#L82) - skipping this event will prevent the inactive iframe from opening
-- [luigi.navigate.ok](https://github.com/SAP/luigi/blob/main/client/src/lifecycleManager.js#L124) - skipping this event will prevent navigation 
-- [luigi.ux.confirmationModal.show](https://github.com/SAP/luigi/blob/main/client/src/uxManager.js#L102) -  skipping this event will prevent the showing of a [confirmation modal](luigi-client-api.md#showconfirmationmodal) 
-- [luigi.ux.alert.show](https://github.com/SAP/luigi/blob/main/client/src/uxManager.js#L172) - skipping this event will prevent the showing of an [alert](luigi-client-api.md#showalert) 
+- [luigi.navigation.open](https://github.com/luigi-project/luigi/blob/main/client/src/linkManager.js#L82) - skipping this event will prevent the inactive iframe from opening
+- [luigi.navigate.ok](https://github.com/luigi-project/luigi/blob/main/client/src/lifecycleManager.js#L124) - skipping this event will prevent navigation 
+- [luigi.ux.confirmationModal.show](https://github.com/luigi-project/luigi/blob/main/client/src/uxManager.js#L102) -  skipping this event will prevent the showing of a [confirmation modal](luigi-client-api.md#showconfirmationmodal) 
+- [luigi.ux.alert.show](https://github.com/luigi-project/luigi/blob/main/client/src/uxManager.js#L172) - skipping this event will prevent the showing of an [alert](luigi-client-api.md#showalert) 
 
 ### skipEventsWhenInactive
 - **type**: array of strings

--- a/docs/content-guidelines.md
+++ b/docs/content-guidelines.md
@@ -14,7 +14,7 @@ This page contains instructions on how to create documentation for Luigi. It def
 
 Luigi documentation is written in Markdown and stored on GitHub. The Markdown files are then rendered on the main documentation page using Sapper. Find more about what GitHub-flavored Markdown is [here](https://github.github.com/gfm).
 
-Documentation resides in the `luigi/docs` folder in the [Luigi repository](https://github.com/SAP/luigi).
+Documentation resides in the `luigi/docs` folder in the [Luigi repository](https://github.com/luigi-project/luigi).
 
 ## Structure
 
@@ -49,9 +49,9 @@ Documentation on the Luigi website follows the structure below. When adding a ne
 
 ### Examples
 
-- [Angular](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-angular)
-- [Vue](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-vue)
-- [React](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-react)
+- [Angular](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-angular)
+- [Vue](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-vue)
+- [React](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-react)
 
 ## Metadata
 
@@ -122,7 +122,7 @@ For an example, you can look at the already existing functions, in this case [fr
    */
 ```
 
-2. Save and commit your changes. If you have run `npm install` in the root folder (as indicated in the [contributing guidelines](https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md)), documentation should be automatically generated and added to the `luigi-core-api.md` or `luigi-client-api.md` file on push to your branch origin. If not, you can run `npm run --prefix=scripts docu` manually.
+2. Save and commit your changes. If you have run `npm install` in the root folder (as indicated in the [contributing guidelines](https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md)), documentation should be automatically generated and added to the `luigi-core-api.md` or `luigi-client-api.md` file on push to your branch origin. If not, you can run `npm run --prefix=scripts docu` manually.
 
 
 ## Audience and language

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,7 +17,7 @@ meta -->
 # Frequently asked questions about Luigi
 
 <!-- add-attribute:class:success -->
->**TIP:** You can go to our [GitHub Discussions page](https://github.com/SAP/luigi/discussions) to find the answers to more questions not listed here.
+>**TIP:** You can go to our [GitHub Discussions page](https://github.com/luigi-project/luigi/discussions) to find the answers to more questions not listed here.
 
 This page contains FAQs about Luigi in the following categories:
 - [Basics](#basic-questions)
@@ -53,11 +53,11 @@ No, Luigi can be used independently of SAP for a variety of purposes. You can fi
 
 ### What is the difference between Luigi and SAPUI5/OpenUI5?
 
-You can find a detailed response to this question [here](https://github.com/SAP/luigi/discussions/2809#discussioncomment-3137780).
+You can find a detailed response to this question [here](https://github.com/luigi-project/luigi/discussions/2809#discussioncomment-3137780).
 
 ### Where can I download Luigi?
 
-The Luigi project can be found on [GitHub](https://github.com/SAP/luigi). Depending on the UI framework you use, there are different setups for Luigi. You can find more information here: [application setup](application-setup.md).
+The Luigi project can be found on [GitHub](https://github.com/luigi-project/luigi). Depending on the UI framework you use, there are different setups for Luigi. You can find more information here: [application setup](application-setup.md).
 
 ### Does Luigi provide micro frontend to micro frontend communication?
 
@@ -517,7 +517,7 @@ There are a few options to do that at the moment:
                 {
                   label: "Luigi Github Page",
                   externalLink: {
-                    url: "https://github.com/SAP/luigi",
+                    url: "https://github.com/luigi-project/luigi",
                   },
                 },
                 {
@@ -725,6 +725,6 @@ One way would be to bind the Luigi app root to a specific [dom element](https://
 
 ### Where can I find the source code for Luigi Fiddle?
 
-Luigi is an open-source project. You can find the source code on our [GitHub repository](https://github.com/SAP/luigi/tree/main/website/fiddle).
+Luigi is an open-source project. You can find the source code on our [GitHub repository](https://github.com/luigi-project/luigi/tree/main/website/fiddle).
 
 <!-- accordion:end -->

--- a/docs/framework-support-libraries.md
+++ b/docs/framework-support-libraries.md
@@ -27,7 +27,7 @@ On this page, you can find more information about Luigi Client support libraries
 
 ## Angular Support Library
 
-The [ClientSupportAngular](https://github.com/SAP/luigi/tree/main/client-frameworks-support/client-support-angular/projects/client-support-angular) library provides several features which make it easier to run your Angular application inside the Luigi micro frontend framework.
+The [ClientSupportAngular](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/client-support-angular/projects/client-support-angular) library provides several features which make it easier to run your Angular application inside the Luigi micro frontend framework.
 
 
 ### How to use the library
@@ -197,7 +197,7 @@ To make mocking of Luigi Core easier, you can use a range of utility functions a
 
 ## UI5 Support Library
 ​
-The [Luigi Client UI5 Support Library](https://github.com/SAP/luigi/tree/main/client-frameworks-support/client-support-ui5) offers a set [features](#features) which make it easier to use the Luigi micro frontend framework with UI5 applications.  
+The [Luigi Client UI5 Support Library](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/client-support-ui5) offers a set [features](#features) which make it easier to use the Luigi micro frontend framework with UI5 applications.  
 ​
 ### How to use the library
 

--- a/docs/general-settings.md
+++ b/docs/general-settings.md
@@ -123,7 +123,7 @@ Luigi.setConfig({
 
 ### customSandboxRules
 - **type**: array
-- **description**: an array of custom rules for the content in the iframe. You can extend the [Luigi default sandbox rules](https://github.com/SAP/luigi/blob/af1deebb392dcec6490f72576e32eb5853a894bc/core/src/utilities/helpers/iframe-helpers.js#L140) by adding further rules.
+- **description**: an array of custom rules for the content in the iframe. You can extend the [Luigi default sandbox rules](https://github.com/luigi-project/luigi/blob/af1deebb392dcec6490f72576e32eb5853a894bc/core/src/utilities/helpers/iframe-helpers.js#L140) by adding further rules.
 
 ### customTranslationImplementation
 - **type**: object/function returning an object
@@ -308,7 +308,7 @@ This function is called with the following parameters:
 
 You can check whether the user's browser supports third-party cookies by defining a **thirdPartyCookieCheck** object which expects a function called **thirdPartyCookieErrorHandling**, optional **disabled** and **thirdPartyCookiesScriptLocation** parameters. When **thirdPartyCookiesScriptLocation** is set, the Luigi Core application checks third-party cookie support only once and not on every micro frontend call. If it is *not* set, the Luigi Core application checks third-party cookie support whenever a micro frontend is loaded.
 
-To detect whether the user's browser supports the mechanism, use the script in the [`third-party-cookies`](https://github.com/SAP/luigi/tree/main/core/third-party-cookies) catalog. Deploy this file on a domain different from your main application's and set **thirdPartyCookieScriptLocation** to the `init.html` file. During initialization, Luigi detects cookies support and produces an alert if cookies are disabled in the user's browser.
+To detect whether the user's browser supports the mechanism, use the script in the [`third-party-cookies`](https://github.com/luigi-project/luigi/tree/main/core/third-party-cookies) catalog. Deploy this file on a domain different from your main application's and set **thirdPartyCookieScriptLocation** to the `init.html` file. During initialization, Luigi detects cookies support and produces an alert if cookies are disabled in the user's browser.
 
 ### Parameters
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ Some benefits of a micro frontend architecture include:
 
 ### Main features
 
-<img src="https://github.com/SAP/luigi/blob/main/docs/assets/luigi-overview-diagram.jpg?raw=true" alt="Graphic showing main Luigi components" width="600"/>
+<img src="https://github.com/luigi-project/luigi/blob/main/docs/assets/luigi-overview-diagram.jpg?raw=true" alt="Graphic showing main Luigi components" width="600"/>
 
 Luigi consists of two main parts:
 
@@ -157,13 +157,13 @@ The [Luigi Fiddle](https://fiddle.luigi-project.io/) website is a sandbox playgr
 ### "Hello World" examples
 
 In the **Examples** section of our documentation, you can find links to several "Hello World" example applications which can help you explore Luigi's functions:
-* [Angular](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-angular)
-* [React](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-react)
-* [Vue](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-vue)
-* [OpenUI5](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-openui5)
-* [Svelte](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-svelte)
-* [Plain JavaScript](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-js)
-* [NextJS](https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-next)
+* [Angular](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-angular)
+* [React](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-react)
+* [Vue](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-vue)
+* [OpenUI5](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-openui5)
+* [Svelte](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-svelte)
+* [Plain JavaScript](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-js)
+* [NextJS](https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-next)
 
 You can install them by following the instructions in the `README` file of each example.
 
@@ -179,9 +179,9 @@ Alternatively, the tutorial app can be installed directly by following the `READ
 
 ### e2e example
 
-This example application was created for testing purposes and it includes all possible Luigi features in one place. It is useful if you want to explore our framework in more detail or [contribute](https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md) to the Luigi project.
+This example application was created for testing purposes and it includes all possible Luigi features in one place. It is useful if you want to explore our framework in more detail or [contribute](https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md) to the Luigi project.
 
-You can find the e2e test application and instructions on how to install it [here](https://github.com/SAP/luigi/tree/main/test/e2e-test-application#luigi-sample-and-e2e-test-application-written-in-angular).
+You can find the e2e test application and instructions on how to install it [here](https://github.com/luigi-project/luigi/tree/main/test/e2e-test-application#luigi-sample-and-e2e-test-application-written-in-angular).
 
 ### Advanced scenarios
 
@@ -191,8 +191,8 @@ In the [expert scenarios](advanced-scenarios.md) section of the documentation, y
 
 ## How to obtain support
 
-* [GitHub Discussions](https://github.com/SAP/luigi/discussions) - ask (or answer) questions related to Luigi, search for previously answered questions, and rate the answers for helpfulness.
+* [GitHub Discussions](https://github.com/luigi-project/luigi/discussions) - ask (or answer) questions related to Luigi, search for previously answered questions, and rate the answers for helpfulness.
 
 * [Slack Channel](https://luigi-project.slack.com) - get Luigi updates, contact the Luigi team on Slack, and explore previous discussions.
 
-* [GitHub contribution](https://github.com/SAP/luigi) - if you have a specific improvement idea or want to contribute to Luigi, you can create an [issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) and [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests). Please follow our [contribution guidelines](https://github.com/SAP/luigi/blob/main/CONTRIBUTING.md) when doing so.
+* [GitHub contribution](https://github.com/luigi-project/luigi) - if you have a specific improvement idea or want to contribute to Luigi, you can create an [issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) and [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests). Please follow our [contribution guidelines](https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md) when doing so.

--- a/docs/luigi-client-setup.md
+++ b/docs/luigi-client-setup.md
@@ -67,7 +67,7 @@ import LuigiClient from '@luigi-project/client';
 ### Next.JS
 
 <!-- add-attribute:class:success -->
-> **TIP:** You can find an Next.JS example using Luigi Client [here](https://github.com/SAP/luigi/blob/main/core/examples/luigi-example-next/pages/sample1.js).
+> **TIP:** You can find an Next.JS example using Luigi Client [here](https://github.com/luigi-project/luigi/blob/main/core/examples/luigi-example-next/pages/sample1.js).
 
 1. Add this line to the imports section of the `src/App.js` file:
 

--- a/docs/luigi-compound-container.md
+++ b/docs/luigi-compound-container.md
@@ -90,7 +90,7 @@ You can find more on the Luigi Compound Container [compoundConfig](luigi-compoun
 
 ### Test Application
 
-1. You can find a Luigi Compound Container example application on [GitHub](https://github.com/SAP/luigi/tree/main/container/examples). First, clone the Luigi repository if you haven't already done so:
+1. You can find a Luigi Compound Container example application on [GitHub](https://github.com/luigi-project/luigi/tree/main/container/examples). First, clone the Luigi repository if you haven't already done so:
 
 ```bash
 git clone git@github.com:SAP/luigi.git
@@ -107,7 +107,7 @@ npm run start-examples
 
 The Compound Container example should be available at `http://localhost:2222/#compound-wc-container` in your browser. 
 
-3. Check the [examples folder](https://github.com/SAP/luigi/tree/main/container/examples) to see how Luigi Compound Container is used.
+3. Check the [examples folder](https://github.com/luigi-project/luigi/tree/main/container/examples) to see how Luigi Compound Container is used.
 
 ### API Reference
 To make use of all of the compound container based Luigi functionalities you can take a further look at the API reference:

--- a/docs/luigi-container-events.md
+++ b/docs/luigi-container-events.md
@@ -18,7 +18,7 @@ meta -->
 
 This document outlines the events provided by the Luigi Container.<br/>
 Some events contain an additional payload which can be utilized for internal objectives.<br/>
-In addition you can use standard `addEventListener` function to react on events emmitted by the Luigi Container. Source list of all events can be found [here](https://github.com/SAP/luigi/blob/main/container/src/constants/communication.ts).
+In addition you can use standard `addEventListener` function to react on events emmitted by the Luigi Container. Source list of all events can be found [here](https://github.com/luigi-project/luigi/blob/main/container/src/constants/communication.ts).
 
 ## Event Reference
 
@@ -49,7 +49,7 @@ Payload: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 ### NAVIGATION_REQUEST
 
 Event fired when a navigation has been requested by the micro frontend. <br><br>
-Payload: [NavigationRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [NavigationRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -70,7 +70,7 @@ Payload: [NavigationRequestPayload](https://github.com/SAP/luigi/blob/main/conta
 
 Event fired when the micro frontend requests to show an alert. <br>
 Read more about `showAlert` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showalert). <br><br>
-Payload: [AlertRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [AlertRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -101,7 +101,7 @@ Event fired when the micro frontend has been initialized.
 ### ADD_SEARCH_PARAMS_REQUEST
 
 Event fired when the micro frontend requests the addition of search parameters to the URL. <br><br>
-Payload: [ParamsRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [ParamsRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -117,7 +117,7 @@ Payload: [ParamsRequestPayload](https://github.com/SAP/luigi/blob/main/container
 ### ADD_NODE_PARAMS_REQUEST
 
 Event fired when the micro frontend requests the addition of node parameters to the URL. <br><br>
-Payload: [ParamsRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [ParamsRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -134,7 +134,7 @@ Payload: [ParamsRequestPayload](https://github.com/SAP/luigi/blob/main/container
 
 Event fired when the micro frontend requests to show a confirmation modal. <br>
 Read more about `showConfirmationModal` params [here](https://docs.luigi-project.io/docs/luigi-core-api?section=showconfirmationmodal). <br><br>
-Payload: [ConfirmationModalRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [ConfirmationModalRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -231,7 +231,7 @@ Event fired when the micro frontend requests to set third-party cookies.
 ### GET_CURRENT_ROUTE_REQUEST
 
 Event fired when the micro frontend requests the current app route. <br><br>
-Payload: [CurrentRouteRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [CurrentRouteRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -258,7 +258,7 @@ Event fired to report that the micro frontend's navigation has completed.
 ### UPDATE_MODAL_PATH_DATA_REQUEST
 
 Event fired when the micro frontend requests to update the modal path parameters. <br><br>
-Payload: [ModalPathDataRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [ModalPathDataRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 
@@ -281,7 +281,7 @@ Payload: [ModalPathDataRequestPayload](https://github.com/SAP/luigi/blob/main/co
 
 Event fired when the micro frontend requests to update the modal settings. <br>
 Read more about `updateModalSettings` params [here](https://docs.luigi-project.io/docs/luigi-client-api?section=updatemodalsettings). <br><br>
-Payload: [ModalSettingsRequestPayload](https://github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts)
+Payload: [ModalSettingsRequestPayload](https://github.com/luigi-project/luigi/blob/main/container/typings/constants/event-payloads.ts)
 
 #### Examples
 

--- a/docs/luigi-container.md
+++ b/docs/luigi-container.md
@@ -62,7 +62,7 @@ After importing the package, you can use the Luigi container anywhere in your ap
 
 ### Test Application
 
-1. You can find a Luigi Container example application on [GitHub](https://github.com/SAP/luigi/tree/main/container/examples). First, clone the Luigi repository if you haven't already done so:
+1. You can find a Luigi Container example application on [GitHub](https://github.com/luigi-project/luigi/tree/main/container/examples). First, clone the Luigi repository if you haven't already done so:
 
 ```bash
 git clone git@github.com:SAP/luigi.git
@@ -79,7 +79,7 @@ npm run start-examples
 
 The app should be available at `http://localhost:2222` in your browser. 
 
-3. Check the [examples folder](https://github.com/SAP/luigi/tree/main/container/examples) to see how Luigi Container is used.
+3. Check the [examples folder](https://github.com/luigi-project/luigi/tree/main/container/examples) to see how Luigi Container is used.
 
 ### API Reference
 To make use of all of the container based Luigi functionalities you can take a further look at the API reference:

--- a/docs/luigi-testing-utilities.md
+++ b/docs/luigi-testing-utilities.md
@@ -18,7 +18,7 @@ meta -->
 
 # Luigi Testing Utilities
 
-The [Luigi Testing Utilities](https://github.com/SAP/luigi/tree/main/client-frameworks-support/testing-utilities) are a set of auxiliary functions used to enhance the user experience while testing Luigi-based micro frontends. The functions abstract away Luigi-specific logic from the tester so that it is easier for them to mock and assert Luigi functionality.
+The [Luigi Testing Utilities](https://github.com/luigi-project/luigi/tree/main/client-frameworks-support/testing-utilities) are a set of auxiliary functions used to enhance the user experience while testing Luigi-based micro frontends. The functions abstract away Luigi-specific logic from the tester so that it is easier for them to mock and assert Luigi functionality.
 
 ## LuigiMockUtil
 This class contains certain utility helper functions needed when writing e2e tests with different test frameworks. You can simply import this module into you project and then use an instance of it to test micro frontend functionality.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -47,9 +47,9 @@ Additionally, you need to copy callback assets to your Core application.
 
 To install the plugins, follow these installation guides:
 
-- [OAuth2 Implicit Grant](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oauth2)
-- [OpenID Connect (OIDC)](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oidc)
-- [OpenID Connect (OIDC) with PKCE](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oidc-pkce)
+- [OAuth2 Implicit Grant](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oauth2)
+- [OpenID Connect (OIDC)](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oidc)
+- [OpenID Connect (OIDC) with PKCE](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oidc-pkce)
 
 <!-- add-attribute:class:warning -->
 > **NOTE:** If you already had a custom provider defined, you only need to rename the provider key to `idpProvider`.
@@ -79,7 +79,7 @@ Luigi v2.0 introduced two new important changes in regards to previous versions.
 
 ### Internet Explorer 11 (IE11)
 
-As of Luigi v2.0, **Internet Explorer 11 is no longer supported**. Luigi is compatible with all other modern browsers. We recommend that you switch to another web browser such as Chrome or Edge. If you still need to use IE11, you can use Luigi versions lower than 2.0, all of which can be found on our [GitHub repository](https://github.com/SAP/luigi/releases).
+As of Luigi v2.0, **Internet Explorer 11 is no longer supported**. Luigi is compatible with all other modern browsers. We recommend that you switch to another web browser such as Chrome or Edge. If you still need to use IE11, you can use Luigi versions lower than 2.0, all of which can be found on our [GitHub repository](https://github.com/luigi-project/luigi/releases).
 
 ### Update to Angular 14 and 15
 

--- a/docs/web-component.md
+++ b/docs/web-component.md
@@ -255,6 +255,6 @@ Below is a Luigi web component example configuration which shows 3 web component
 
 ## Examples 
 
-You can find an example of Luigi web components in [Luigi Fiddle](https://fiddle.luigi-project.io) in the last navigation entry on the left. The source code for Fiddle is available on [GitHub](https://github.com/SAP/luigi/tree/main/website/fiddle) as well.
+You can find an example of Luigi web components in [Luigi Fiddle](https://fiddle.luigi-project.io) in the last navigation entry on the left. The source code for Fiddle is available on [GitHub](https://github.com/luigi-project/luigi/tree/main/website/fiddle) as well.
 
-Additionally, our e2e test application includes [web components](https://github.com/SAP/luigi/blob/main/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js#L319) and [compound](https://github.com/SAP/luigi/blob/main/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js#L11) examples as well. To install the e2e app, follow the instructions on [GitHub](https://github.com/SAP/luigi/tree/main/test/e2e-test-application#luigi-sample-and-e2e-test-application-written-in-angular). 
+Additionally, our e2e test application includes [web components](https://github.com/luigi-project/luigi/blob/main/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js#L319) and [compound](https://github.com/luigi-project/luigi/blob/main/test/e2e-test-application/src/luigi-config/extended/projectDetailNav.js#L11) examples as well. To install the e2e app, follow the instructions on [GitHub](https://github.com/luigi-project/luigi/tree/main/test/e2e-test-application#luigi-sample-and-e2e-test-application-written-in-angular). 

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,10 @@
+Lots of links were broken already:
+
+z.B.
+github.com/SAP/luigi/blob/main/container/typings/constants/event-payloads.ts%7CModalPathDataRequestPayload
+
+container/public/dist/custom-elements.json
+
+container/src/constants/communication.ts
+
+container/typings/constants

--- a/plugins/auth/public/auth-oauth2/README.md
+++ b/plugins/auth/public/auth-oauth2/README.md
@@ -18,7 +18,7 @@ meta -->
 
 ## Overview
 
-This [authorization plugin](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oauth2) contains a library that allows your application to extend the [Luigi framework](https://github.com/SAP/luigi/tree/main/core) with an OAuth2 authorization provider.
+This [authorization plugin](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oauth2) contains a library that allows your application to extend the [Luigi framework](https://github.com/luigi-project/luigi/tree/main/core) with an OAuth2 authorization provider.
 Further configuration details can be found in the [main documentation](https://docs.luigi-project.io/docs/authorization-configuration#oauth2-implicit-grant-configuration).
 
 ## Installation

--- a/plugins/auth/public/auth-oauth2/package.json
+++ b/plugins/auth/public/auth-oauth2/package.json
@@ -5,7 +5,7 @@
   "main": "plugin.js",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "publishConfig": {
     "tag": "luigi-plugin-auth-oauth2"

--- a/plugins/auth/public/auth-oidc-pkce/README.md
+++ b/plugins/auth/public/auth-oidc-pkce/README.md
@@ -18,8 +18,8 @@ meta -->
 
 ## Overview
 
-This [authorization plugin](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oidc-pkce) contains a library that allows your application to extend the [Luigi framework](https://github.com/SAP/luigi/tree/main/core) with an OpenID Connect authorization provider.
-Further configuration details can be found in the [main documentation](https://docs.luigi-project.io/docs/authorization-configuration#openid-connect-configuration). The plugin supports only Authorization Code flow with PKCE - for Implict flow please check [older OIDC plugin](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oidc).
+This [authorization plugin](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oidc-pkce) contains a library that allows your application to extend the [Luigi framework](https://github.com/luigi-project/luigi/tree/main/core) with an OpenID Connect authorization provider.
+Further configuration details can be found in the [main documentation](https://docs.luigi-project.io/docs/authorization-configuration#openid-connect-configuration). The plugin supports only Authorization Code flow with PKCE - for Implict flow please check [older OIDC plugin](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oidc).
 
 ## Installation
 

--- a/plugins/auth/public/auth-oidc-pkce/package.json
+++ b/plugins/auth/public/auth-oidc-pkce/package.json
@@ -5,7 +5,7 @@
   "main": "plugin.js",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "publishConfig": {
     "tag": "luigi-plugin-auth-oidc-pkce"

--- a/plugins/auth/public/auth-oidc/README.md
+++ b/plugins/auth/public/auth-oidc/README.md
@@ -18,8 +18,8 @@ meta -->
 
 ## Overview
 
-This [authorization plugin](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oidc) contains a library that allows your application to extend the [Luigi framework](https://github.com/SAP/luigi/tree/main/core) with an OpenID Connect authorization provider.
-Further configuration details can be found in the [main documentation](https://docs.luigi-project.io/docs/authorization-configuration#openid-connect-configuration). We support Authorization Code with PKCE and Implicit Grant flow. If you don't need Implict flow please use [OIDC plugin with PKCE](https://github.com/SAP/luigi/tree/main/plugins/auth/public/auth-oidc-pkce) instead of this one.
+This [authorization plugin](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oidc) contains a library that allows your application to extend the [Luigi framework](https://github.com/luigi-project/luigi/tree/main/core) with an OpenID Connect authorization provider.
+Further configuration details can be found in the [main documentation](https://docs.luigi-project.io/docs/authorization-configuration#openid-connect-configuration). We support Authorization Code with PKCE and Implicit Grant flow. If you don't need Implict flow please use [OIDC plugin with PKCE](https://github.com/luigi-project/luigi/tree/main/plugins/auth/public/auth-oidc-pkce) instead of this one.
 
 ## Installation
 

--- a/plugins/auth/public/auth-oidc/package.json
+++ b/plugins/auth/public/auth-oidc/package.json
@@ -5,7 +5,7 @@
   "main": "plugin.js",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "publishConfig": {
     "tag": "luigi-plugin-auth-oidc"

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -4,7 +4,7 @@
   "description": "luigi-auth-plugin-* development versions, only the public folders are being published to npm as a package",
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/SAP/luigi.git"
+    "url": "ssh://github.com/luigi-project/luigi.git"
   },
   "scripts": {
     "bundle": "npm run bundle-evergreen",

--- a/scripts/setup/angular.sh
+++ b/scripts/setup/angular.sh
@@ -23,9 +23,9 @@ mkdir public/assets
 mv src/index.html src/angular.html
 
 # download assets
-curl https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/assets/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/assets/luigi-config.es6.js > public/assets/luigi-config.es6.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/scripts/setup/assets/basicMicroFrontend.html > public/assets/basicMicroFrontend.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/assets/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/assets/luigi-config.es6.js > public/assets/luigi-config.es6.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/scripts/setup/assets/basicMicroFrontend.html > public/assets/basicMicroFrontend.html
 
 # string replacements in some files
 sed 's#"src/index.html"#"src/angular.html"#g' angular.json > tmp.json && mv tmp.json angular.json

--- a/scripts/setup/no-framework.sh
+++ b/scripts/setup/no-framework.sh
@@ -15,19 +15,19 @@ echo ""
 mkdir $folder && cd $folder
 
 # download the package.json
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/package.json > package.json
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/package.json > package.json
 
 npm i 
 mkdir -p public/
 mkdir -p public/views
 
 # download assets from core/examples folder
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/favicon.ico > public/favicon.ico
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/logo.png > public/logo.png
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/luigi-config.js > public/luigi-config.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/views/home.html > public/views/home.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-js/public/views/sample1.html > public/views/sample1.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/favicon.ico > public/favicon.ico
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/logo.png > public/logo.png
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/luigi-config.js > public/luigi-config.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/views/home.html > public/views/home.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-js/public/views/sample1.html > public/views/sample1.html
 
 echo "Running server with command: npm run start"
 npm run start

--- a/scripts/setup/openui5.sh
+++ b/scripts/setup/openui5.sh
@@ -15,7 +15,7 @@ mkdir $folder && cd $folder
 echo "Creating folders and downloading example assets"
 mkdir -p ./webapp/home ./webapp/libs ./webapp/sample1 ./webapp/sample2 ./webapp/i18n
 
-export UI5EX_REPO_URL="https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-openui5"
+export UI5EX_REPO_URL="https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-openui5"
 
 curl --silent $UI5EX_REPO_URL/webapp/sample2/Sample2.view.xml > ./webapp/sample2/Sample2.view.xml
 curl --silent $UI5EX_REPO_URL/webapp/sample2/sample2.html > ./webapp/sample2/sample2.html

--- a/scripts/setup/react.sh
+++ b/scripts/setup/react.sh
@@ -53,20 +53,20 @@ echo '{
 }'>.eslintrc.json
 # downloads
 mkdir -p src/luigi-config
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/logo.png > public/logo.png
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/sampleapp.html > public/sampleapp.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/public/luigi-config-file.js > src/luigi-config/luigi-config.es6.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/logo.png > public/logo.png
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/sampleapp.html > public/sampleapp.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/public/luigi-config-file.js > src/luigi-config/luigi-config.es6.js
 
 
 # add index.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/index-file.js > src/index.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/index-file.js > src/index.js
 
 # add views
 mkdir src/views
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/views/home.js > src/views/home.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/views/sample1.js > src/views/sample1.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-react/src/views/sample2.js > src/views/sample2.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/views/home.js > src/views/home.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/views/sample1.js > src/views/sample1.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-react/src/views/sample2.js > src/views/sample2.js
 
 npm i
 npm run buildConfig

--- a/scripts/setup/vue.sh
+++ b/scripts/setup/vue.sh
@@ -20,7 +20,7 @@ fi
 vue create -d $folder && cd $folder
 
 # install dependencies
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/package.json > package.json
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/package.json > package.json
 npm i
 
 mkdir -p src/views src/router 
@@ -29,20 +29,20 @@ mkdir -p src/views src/router
 rm public/index.html src/app.vue # remove default index, will be replaced with example assets
 rm -rf src/components
 
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/vite.config.mjs > vite.config.mjs
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/vite.config.mjs > vite.config.mjs
 # fetch assets from vue example
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/index.html > index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/public/index.html > public/index.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/public/sampleapp.html > sampleapp.html
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/app.vue > src/app.vue
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/main.js > src/main.js
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/public/luigi-config.js > public/luigi-config.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/index.html > index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/public/index.html > public/index.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/public/sampleapp.html > sampleapp.html
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/app.vue > src/app.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/main.js > src/main.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/public/luigi-config.js > public/luigi-config.js
 
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/router/index.js > src/router/index.js
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/router/index.js > src/router/index.js
 
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/views/home.vue > src/views/home.vue
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/views/sample1.vue > src/views/sample1.vue
-curl https://raw.githubusercontent.com/SAP/luigi/main/core/examples/luigi-example-vue/src/views/sample2.vue > src/views/sample2.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/views/home.vue > src/views/home.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/views/sample1.vue > src/views/sample1.vue
+curl https://raw.githubusercontent.com/luigi-project/luigi/main/core/examples/luigi-example-vue/src/views/sample2.vue > src/views/sample2.vue
 
 npm run build
 npm run serve

--- a/scripts/testCompatibility.sh
+++ b/scripts/testCompatibility.sh
@@ -115,7 +115,7 @@ promptForTag() {
     echo "No tag provided, pick one of the last releases;"
     echo "Fetching current releases are being fetched from github."
     echo ""
-    rawReleases=`curl -s https://api.github.com/repos/SAP/luigi/releases`
+    rawReleases=`curl -s https://api.github.com/repos/luigi-project/luigi/releases`
     # rawReleases=`cat releases`
 
     count=1;
@@ -166,7 +166,7 @@ checkoutLuigiToTestfolder() {
     if [ "$CI" == "true" ]; then
       # gh actions
       echoe "Clone using gh cli"
-      gh repo clone https://github.com/SAP/luigi.git $LUIGI_DIR_TESTING
+      gh repo clone https://github.com/luigi-project/luigi.git $LUIGI_DIR_TESTING
     else
       # osx localhost
       echoe "Clone using ssh"

--- a/scripts/tools/release-cli/release-cli.js
+++ b/scripts/tools/release-cli/release-cli.js
@@ -76,7 +76,7 @@ if (process.env.NIGHTLY === 'true' && !process.env.NIGHTLY_VERSION) {
  * FNS
  */
 async function getReleases() {
-  const input = await asyncRequest('https://api.github.com/repos/SAP/luigi/releases', {
+  const input = await asyncRequest('https://api.github.com/repos/luigi-project/luigi/releases', {
     headers: {
       'User-Agent': 'Luigi Release CLI'
     }
@@ -222,7 +222,7 @@ function addToChangelog(versionText, changelog, lastline) {
     // strip committers part
     changelog = changelog.slice(0, changelog.indexOf('#### Committers'));
 
-    const lastline = `[v${input.version}]: https://github.com/SAP/luigi/compare/${prevVersion}...v${input.version}`;
+    const lastline = `[v${input.version}]: https://github.com/luigi-project/luigi/compare/${prevVersion}...v${input.version}`;
 
     logHeadline('\nPrepared Changelog:');
     console.log(changelog);

--- a/test/e2e-test-application/src/luigi-config/extended/navigation.js
+++ b/test/e2e-test-application/src/luigi-config/extended/navigation.js
@@ -217,7 +217,7 @@ class Navigation {
     },
     {
       externalLink: {
-        url: 'https://github.com/SAP/luigi',
+        url: 'https://github.com/luigi-project/luigi',
         sameWindow: true
       },
       label: 'Git',
@@ -471,7 +471,7 @@ class Navigation {
       {
         label: 'Luigi in Github',
         externalLink: {
-          url: 'https://github.com/SAP/luigi',
+          url: 'https://github.com/luigi-project/luigi',
           sameWindow: false
         }
       }

--- a/website/docs/package.json
+++ b/website/docs/package.json
@@ -15,7 +15,7 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test:unit": "vitest",
-    "fetchversions": "curl -H \"Accept: application/vnd.github.v3+json\" https://api.github.com/repos/SAP/luigi/tags?per_page=100 > ./public/versions.json",
+    "fetchversions": "curl -H \"Accept: application/vnd.github.v3+json\" https://api.github.com/repos/luigi-project/luigi/tags?per_page=100 > ./public/versions.json",
     "pre-build": "sh ./scripts/move-export.sh && npm run fetchversions && npm run compilecorescss && npm run bundleLuigiConfig && npm run generateSitemap && npm run buildMarkdownDocu",
     "copy-docs-html": "cp -R build/* public/docu-microfrontend",
     "compilecorescss": "sass --no-source-map ./src/luigi-config/styles/index.scss ./public/coreStyles.css",

--- a/website/docs/scripts/mocks/links.md
+++ b/website/docs/scripts/mocks/links.md
@@ -1,7 +1,7 @@
 # Links
 
 [Internal Link](some-file.md)<br>
-[Internal Full Link](https://github.com/SAP/luigi/blob/main/docs/application-setup.md)<br>
+[Internal Full Link](https://github.com/luigi-project/luigi/blob/main/docs/application-setup.md)<br>
 [External Link](https://luigi-project.io)<br>
 [Anchor Link](#noframework) <br>
 

--- a/website/docs/src/luigi-config/extended/navigation.js
+++ b/website/docs/src/luigi-config/extended/navigation.js
@@ -68,7 +68,7 @@ class Navigation {
       {
         label: 'Github',
         externalLink: {
-          url: 'https://github.com/SAP/luigi'
+          url: 'https://github.com/luigi-project/luigi'
         },
         icon: 'github'
       }
@@ -94,7 +94,7 @@ class Navigation {
       {
         label: 'Luigi in Github',
         externalLink: {
-          url: 'https://github.com/SAP/luigi',
+          url: 'https://github.com/luigi-project/luigi',
           sameWindow: false
         }
       }

--- a/website/docs/src/markdown-conversion/unified-plugins/rehype-luigi-linkparser.js
+++ b/website/docs/src/markdown-conversion/unified-plugins/rehype-luigi-linkparser.js
@@ -24,7 +24,7 @@ export default function luigiLinkParser(options) {
   };
 
   function modify(node, prop) {
-    const githubMain = 'https://github.com/SAP/luigi/blob/main/';
+    const githubMain = 'https://github.com/luigi-project/luigi/blob/main/';
     if (hasProperty(node, prop)) {
       var parsed = url.parse(node.properties[prop]);
       if (

--- a/website/docs/src/markdown-conversion/unified-plugins/rehype-luigi-oldVersions.js
+++ b/website/docs/src/markdown-conversion/unified-plugins/rehype-luigi-oldVersions.js
@@ -15,7 +15,7 @@ export default function oldVersion() {
         const wrapper = h('div.custom-select');
         const oldVerDropdown = h('select.oldverdrop');
         oldVerDropdown.properties.onchange =
-          "window.open('https://github.com/SAP/luigi/blob/' + event.target.value + '/docs/README.md', '_blank'); event.target.value=0;";
+          "window.open('https://github.com/luigi-project/luigi/blob/' + event.target.value + '/docs/README.md', '_blank'); event.target.value=0;";
         wrapper.children.push(oldVerDropdown);
         parent.children.splice(index + 1, 0, wrapper);
         const tagLinks = [];

--- a/website/docs/static/public/navigation-nodes.json
+++ b/website/docs/static/public/navigation-nodes.json
@@ -12,7 +12,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-angular"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-angular"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -32,7 +32,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-vue"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-vue"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -52,7 +52,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-react"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-react"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -72,7 +72,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-js"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-js"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -92,7 +92,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-openui5"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-openui5"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -112,7 +112,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-svelte"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-svelte"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -132,7 +132,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/core/examples/luigi-example-next"
+      "url": "https://github.com/luigi-project/luigi/tree/main/core/examples/luigi-example-next"
     },
     "metaData": {
       "categoryPosition": 9,
@@ -152,7 +152,7 @@
       "label": "Examples"
     },
     "externalLink": {
-      "url": "https://github.com/SAP/luigi/tree/main/container/examples"
+      "url": "https://github.com/luigi-project/luigi/tree/main/container/examples"
     },
     "metaData": {
       "categoryPosition": 9,

--- a/website/docs/static/public/versions.json
+++ b/website/docs/static/public/versions.json
@@ -1,1001 +1,1001 @@
 [
   {
     "name": "v2.2.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v2.2.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v2.2.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v2.2.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v2.2.1",
     "commit": {
       "sha": "ed45b94c2fb0a2eca905f0ece66a4873236d3c01",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ed45b94c2fb0a2eca905f0ece66a4873236d3c01"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ed45b94c2fb0a2eca905f0ece66a4873236d3c01"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92Mi4yLjE="
   },
   {
     "name": "v2.2.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v2.2.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v2.2.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v2.2.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v2.2.0",
     "commit": {
       "sha": "f5990937c2d969a5d43e45e5fbda54a4813f1316",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/f5990937c2d969a5d43e45e5fbda54a4813f1316"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/f5990937c2d969a5d43e45e5fbda54a4813f1316"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92Mi4yLjA="
   },
   {
     "name": "v2.1.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v2.1.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v2.1.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v2.1.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v2.1.0",
     "commit": {
       "sha": "2f02e7813348ee3eb570e09e3f53b8c0bb5fa3bd",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/2f02e7813348ee3eb570e09e3f53b8c0bb5fa3bd"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/2f02e7813348ee3eb570e09e3f53b8c0bb5fa3bd"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92Mi4xLjA="
   },
   {
     "name": "v2.0.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v2.0.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v2.0.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v2.0.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v2.0.1",
     "commit": {
       "sha": "5d3a03c7c17dd9e4a2430fc14500a9215119e890",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/5d3a03c7c17dd9e4a2430fc14500a9215119e890"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/5d3a03c7c17dd9e4a2430fc14500a9215119e890"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92Mi4wLjE="
   },
   {
     "name": "v2.0.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v2.0.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v2.0.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v2.0.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v2.0.0",
     "commit": {
       "sha": "f8ebe54c5b42077903bf06c8dea4a98639188df2",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/f8ebe54c5b42077903bf06c8dea4a98639188df2"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/f8ebe54c5b42077903bf06c8dea4a98639188df2"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92Mi4wLjA="
   },
   {
     "name": "v1.26.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.26.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.26.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.26.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.26.0",
     "commit": {
       "sha": "5136198661e4cdfe3e60b36273e6489c964b45a7",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/5136198661e4cdfe3e60b36273e6489c964b45a7"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/5136198661e4cdfe3e60b36273e6489c964b45a7"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yNi4w"
   },
   {
     "name": "v1.25.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.25.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.25.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.25.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.25.1",
     "commit": {
       "sha": "ff79347d13655c942c17ba2a93a5dfb613791dcc",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ff79347d13655c942c17ba2a93a5dfb613791dcc"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ff79347d13655c942c17ba2a93a5dfb613791dcc"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yNS4x"
   },
   {
     "name": "v1.25.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.25.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.25.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.25.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.25.0",
     "commit": {
       "sha": "340d78bac39949859d35cd0b9901c949fa21ad58",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/340d78bac39949859d35cd0b9901c949fa21ad58"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/340d78bac39949859d35cd0b9901c949fa21ad58"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yNS4w"
   },
   {
     "name": "v1.24.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.24.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.24.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.24.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.24.0",
     "commit": {
       "sha": "5163f2c2dcc6d08b4061d3e17507855f94aef530",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/5163f2c2dcc6d08b4061d3e17507855f94aef530"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/5163f2c2dcc6d08b4061d3e17507855f94aef530"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yNC4w"
   },
   {
     "name": "v1.23.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.23.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.23.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.23.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.23.1",
     "commit": {
       "sha": "d2b8c73233ea3357f95ddd54dbd8962890d7d9df",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/d2b8c73233ea3357f95ddd54dbd8962890d7d9df"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/d2b8c73233ea3357f95ddd54dbd8962890d7d9df"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yMy4x"
   },
   {
     "name": "v1.23.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.23.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.23.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.23.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.23.0",
     "commit": {
       "sha": "c9bff7371a63d66e31899ab43618929a8a1d3aab",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/c9bff7371a63d66e31899ab43618929a8a1d3aab"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/c9bff7371a63d66e31899ab43618929a8a1d3aab"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yMy4w"
   },
   {
     "name": "v1.22.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.22.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.22.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.22.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.22.0",
     "commit": {
       "sha": "ff8091fbf9a24adda6d9044993bb25f346be632f",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ff8091fbf9a24adda6d9044993bb25f346be632f"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ff8091fbf9a24adda6d9044993bb25f346be632f"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yMi4w"
   },
   {
     "name": "v1.21.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.21.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.21.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.21.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.21.0",
     "commit": {
       "sha": "b1a7d1402c6575d58c2f9a0327bec50783d00f3f",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/b1a7d1402c6575d58c2f9a0327bec50783d00f3f"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/b1a7d1402c6575d58c2f9a0327bec50783d00f3f"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yMS4w"
   },
   {
     "name": "v1.20.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.20.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.20.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.20.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.20.1",
     "commit": {
       "sha": "940d90ecc40d481309a4709555e4972741b26b97",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/940d90ecc40d481309a4709555e4972741b26b97"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/940d90ecc40d481309a4709555e4972741b26b97"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yMC4x"
   },
   {
     "name": "v1.20.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.20.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.20.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.20.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.20.0",
     "commit": {
       "sha": "f575ab68ea43fb90d6924b125d5d4585fe4e289d",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/f575ab68ea43fb90d6924b125d5d4585fe4e289d"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/f575ab68ea43fb90d6924b125d5d4585fe4e289d"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yMC4w"
   },
   {
     "name": "v1.19.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.19.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.19.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.19.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.19.0",
     "commit": {
       "sha": "02444e86f4621f7a87b3009e8ce9d5b04e472d14",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/02444e86f4621f7a87b3009e8ce9d5b04e472d14"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/02444e86f4621f7a87b3009e8ce9d5b04e472d14"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xOS4w"
   },
   {
     "name": "v1.18.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.18.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.18.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.18.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.18.1",
     "commit": {
       "sha": "bde1963374dd340760bafdf66ec52fcb8a6f9120",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/bde1963374dd340760bafdf66ec52fcb8a6f9120"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/bde1963374dd340760bafdf66ec52fcb8a6f9120"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xOC4x"
   },
   {
     "name": "v1.18.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.18.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.18.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.18.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.18.0",
     "commit": {
       "sha": "c2525bc78c7bcc58f275e2a353336ddecc6d033e",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/c2525bc78c7bcc58f275e2a353336ddecc6d033e"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/c2525bc78c7bcc58f275e2a353336ddecc6d033e"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xOC4w"
   },
   {
     "name": "v1.17.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.17.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.17.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.17.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.17.0",
     "commit": {
       "sha": "67c22ebb71e3856595bfcd0a4bc517978a8b0751",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/67c22ebb71e3856595bfcd0a4bc517978a8b0751"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/67c22ebb71e3856595bfcd0a4bc517978a8b0751"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNy4w"
   },
   {
     "name": "v1.16.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.16.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.16.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.16.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.16.2",
     "commit": {
       "sha": "0908e9183c4c9ae028ece5f47ddc8c49b578c1ac",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/0908e9183c4c9ae028ece5f47ddc8c49b578c1ac"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/0908e9183c4c9ae028ece5f47ddc8c49b578c1ac"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNi4y"
   },
   {
     "name": "v1.16.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.16.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.16.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.16.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.16.1",
     "commit": {
       "sha": "be5debb4806137754696f91bb7b5fae282cce813",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/be5debb4806137754696f91bb7b5fae282cce813"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/be5debb4806137754696f91bb7b5fae282cce813"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNi4x"
   },
   {
     "name": "v1.16.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.16.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.16.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.16.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.16.0",
     "commit": {
       "sha": "79d57a56dffc6be6e31ede71b127536995ad110a",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/79d57a56dffc6be6e31ede71b127536995ad110a"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/79d57a56dffc6be6e31ede71b127536995ad110a"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNi4w"
   },
   {
     "name": "v1.15.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.15.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.15.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.15.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.15.0",
     "commit": {
       "sha": "cb9188ed860f0b05b9d79721fd708ea835cdec6b",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/cb9188ed860f0b05b9d79721fd708ea835cdec6b"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/cb9188ed860f0b05b9d79721fd708ea835cdec6b"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNS4w"
   },
   {
     "name": "v1.14.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.14.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.14.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.14.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.14.3",
     "commit": {
       "sha": "8bbce17227170b38f9330d656d4fdaa102d5fad3",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/8bbce17227170b38f9330d656d4fdaa102d5fad3"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/8bbce17227170b38f9330d656d4fdaa102d5fad3"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNC4z"
   },
   {
     "name": "v1.14.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.14.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.14.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.14.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.14.2",
     "commit": {
       "sha": "dc078aca0577a79ceeaa6cd9e1b487c7e0fdd4d4",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/dc078aca0577a79ceeaa6cd9e1b487c7e0fdd4d4"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/dc078aca0577a79ceeaa6cd9e1b487c7e0fdd4d4"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNC4y"
   },
   {
     "name": "v1.14.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.14.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.14.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.14.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.14.1",
     "commit": {
       "sha": "fed82b23fce6dbd7d8e5a55f957509ea4cc43b75",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/fed82b23fce6dbd7d8e5a55f957509ea4cc43b75"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/fed82b23fce6dbd7d8e5a55f957509ea4cc43b75"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNC4x"
   },
   {
     "name": "v1.14.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.14.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.14.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.14.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.14.0",
     "commit": {
       "sha": "afc29b6230bc6044dfb8e52581294d325ee9343d",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/afc29b6230bc6044dfb8e52581294d325ee9343d"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/afc29b6230bc6044dfb8e52581294d325ee9343d"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xNC4w"
   },
   {
     "name": "v1.13.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.13.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.13.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.13.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.13.0",
     "commit": {
       "sha": "0604859b771c4febab891d3cf69b7a3a0bd518b6",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/0604859b771c4febab891d3cf69b7a3a0bd518b6"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/0604859b771c4febab891d3cf69b7a3a0bd518b6"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xMy4w"
   },
   {
     "name": "v1.12.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.12.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.12.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.12.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.12.1",
     "commit": {
       "sha": "dac7fee3cf40c8035fc0ec7055cce1f2dc8432aa",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/dac7fee3cf40c8035fc0ec7055cce1f2dc8432aa"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/dac7fee3cf40c8035fc0ec7055cce1f2dc8432aa"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xMi4x"
   },
   {
     "name": "v1.12.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.12.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.12.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.12.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.12.0",
     "commit": {
       "sha": "1e1e7e2ab03b1774d233c4291779c415aa426087",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1e1e7e2ab03b1774d233c4291779c415aa426087"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1e1e7e2ab03b1774d233c4291779c415aa426087"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xMi4w"
   },
   {
     "name": "v1.11.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.11.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.11.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.11.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.11.0",
     "commit": {
       "sha": "2ff707b8cfd938aef3751d45c5c7b9629cda6783",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/2ff707b8cfd938aef3751d45c5c7b9629cda6783"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/2ff707b8cfd938aef3751d45c5c7b9629cda6783"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xMS4w"
   },
   {
     "name": "v1.10.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.10.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.10.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.10.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.10.0",
     "commit": {
       "sha": "3ce1ffa73b9bac26330e59ebd8f40e9e8406b2b1",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/3ce1ffa73b9bac26330e59ebd8f40e9e8406b2b1"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/3ce1ffa73b9bac26330e59ebd8f40e9e8406b2b1"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xMC4w"
   },
   {
     "name": "v1.9.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.9.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.9.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.9.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.9.0",
     "commit": {
       "sha": "ee55877758ee91e076c4890a0fbd7ed21339eed0",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ee55877758ee91e076c4890a0fbd7ed21339eed0"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ee55877758ee91e076c4890a0fbd7ed21339eed0"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS45LjA="
   },
   {
     "name": "v1.8.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.8.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.8.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.8.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.8.1",
     "commit": {
       "sha": "f743290945a30db4fd7e19c80c75adcaa41bcc5b",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/f743290945a30db4fd7e19c80c75adcaa41bcc5b"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/f743290945a30db4fd7e19c80c75adcaa41bcc5b"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS44LjE="
   },
   {
     "name": "v1.8.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.8.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.8.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.8.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.8.0",
     "commit": {
       "sha": "92b8256533d1743c40c3bc26a92c92699b02f506",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/92b8256533d1743c40c3bc26a92c92699b02f506"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/92b8256533d1743c40c3bc26a92c92699b02f506"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS44LjA="
   },
   {
     "name": "v1.7.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.7.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.7.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.7.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.7.1",
     "commit": {
       "sha": "987d377f30ce10cf11589779943f6bb443a3b215",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/987d377f30ce10cf11589779943f6bb443a3b215"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/987d377f30ce10cf11589779943f6bb443a3b215"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS43LjE="
   },
   {
     "name": "v1.7.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.7.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.7.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.7.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.7.0",
     "commit": {
       "sha": "d5eeb8ab0206705cde20ecdf9933d7d67d744265",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/d5eeb8ab0206705cde20ecdf9933d7d67d744265"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/d5eeb8ab0206705cde20ecdf9933d7d67d744265"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS43LjA="
   },
   {
     "name": "v1.6.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.6.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.6.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.6.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.6.0",
     "commit": {
       "sha": "e651942f1e2878f1139e721b0f29533dfd7330d0",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/e651942f1e2878f1139e721b0f29533dfd7330d0"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/e651942f1e2878f1139e721b0f29533dfd7330d0"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS42LjA="
   },
   {
     "name": "v1.5.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.5.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.5.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.5.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.5.0",
     "commit": {
       "sha": "2a2469a906ad33b45e093d016701af8df8477c64",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/2a2469a906ad33b45e093d016701af8df8477c64"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/2a2469a906ad33b45e093d016701af8df8477c64"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS41LjA="
   },
   {
     "name": "v1.4.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.4.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.4.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.4.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.4.0",
     "commit": {
       "sha": "12213562af847b8348bece1d08681bd100c603d2",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/12213562af847b8348bece1d08681bd100c603d2"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/12213562af847b8348bece1d08681bd100c603d2"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS40LjA="
   },
   {
     "name": "v1.3.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.3.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.3.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.3.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.3.1",
     "commit": {
       "sha": "250752ef9dfa403e3802d3365523adeca2465be4",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/250752ef9dfa403e3802d3365523adeca2465be4"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/250752ef9dfa403e3802d3365523adeca2465be4"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4zLjE="
   },
   {
     "name": "v1.3.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.3.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.3.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.3.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.3.0",
     "commit": {
       "sha": "d05c638f17be51b09a564fb8d70deb5621d1f24b",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/d05c638f17be51b09a564fb8d70deb5621d1f24b"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/d05c638f17be51b09a564fb8d70deb5621d1f24b"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4zLjA="
   },
   {
     "name": "v1.2.4",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.2.4",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.2.4",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.2.4",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.2.4",
     "commit": {
       "sha": "698ae96bfd8ac9b4c2f51760292b14f462febf09",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/698ae96bfd8ac9b4c2f51760292b14f462febf09"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/698ae96bfd8ac9b4c2f51760292b14f462febf09"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yLjQ="
   },
   {
     "name": "v1.2.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.2.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.2.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.2.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.2.3",
     "commit": {
       "sha": "837c33b49e18cebf68729ac6883c587b77c8f13a",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/837c33b49e18cebf68729ac6883c587b77c8f13a"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/837c33b49e18cebf68729ac6883c587b77c8f13a"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yLjM="
   },
   {
     "name": "v1.2.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.2.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.2.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.2.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.2.2",
     "commit": {
       "sha": "2f6bef33d30ae6729dccaff729cdb230f930ef7d",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/2f6bef33d30ae6729dccaff729cdb230f930ef7d"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/2f6bef33d30ae6729dccaff729cdb230f930ef7d"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yLjI="
   },
   {
     "name": "v1.2.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.2.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.2.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.2.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.2.1",
     "commit": {
       "sha": "59ba490029321d4bf6284910394d89f93bf0a2b5",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/59ba490029321d4bf6284910394d89f93bf0a2b5"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/59ba490029321d4bf6284910394d89f93bf0a2b5"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4yLjE="
   },
   {
     "name": "v1.1.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.1.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.1.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.1.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.1.1",
     "commit": {
       "sha": "e0f711cb200557528c072d1b3c2cbea553177767",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/e0f711cb200557528c072d1b3c2cbea553177767"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/e0f711cb200557528c072d1b3c2cbea553177767"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xLjE="
   },
   {
     "name": "v1.1.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.1.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.1.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.1.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.1.0",
     "commit": {
       "sha": "ad7ece0169c2f0701577af3aa48eac65c6687f30",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ad7ece0169c2f0701577af3aa48eac65c6687f30"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ad7ece0169c2f0701577af3aa48eac65c6687f30"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4xLjA="
   },
   {
     "name": "v1.0.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.1",
     "commit": {
       "sha": "9991a892747ee764566a24db342ee4cbe5a65a64",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/9991a892747ee764566a24db342ee4cbe5a65a64"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/9991a892747ee764566a24db342ee4cbe5a65a64"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjE="
   },
   {
     "name": "v1.0.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.0",
     "commit": {
       "sha": "1a1df3fa0bdea2d8b8fe3d0b63a56ab46358ef27",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1a1df3fa0bdea2d8b8fe3d0b63a56ab46358ef27"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1a1df3fa0bdea2d8b8fe3d0b63a56ab46358ef27"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjA="
   },
   {
     "name": "v1.0.0-next.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.0-next.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.0-next.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.0-next.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.0-next.2",
     "commit": {
       "sha": "94cfbee38420b05f7ead971dfe415dcf7962f51e",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/94cfbee38420b05f7ead971dfe415dcf7962f51e"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/94cfbee38420b05f7ead971dfe415dcf7962f51e"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjAtbmV4dC4y"
   },
   {
     "name": "v1.0.0-next.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.0-next.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.0-next.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.0-next.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.0-next.1",
     "commit": {
       "sha": "3b073d6c9e355fc8d18b0e0cd66b193806eac9a2",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/3b073d6c9e355fc8d18b0e0cd66b193806eac9a2"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/3b073d6c9e355fc8d18b0e0cd66b193806eac9a2"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjAtbmV4dC4x"
   },
   {
     "name": "v1.0.0-next.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.0-next.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.0-next.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.0-next.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.0-next.0",
     "commit": {
       "sha": "1734c2c6885e11b3fe9486039cc98af70aadaf97",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1734c2c6885e11b3fe9486039cc98af70aadaf97"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1734c2c6885e11b3fe9486039cc98af70aadaf97"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjAtbmV4dC4w"
   },
   {
     "name": "v1.0.0-bbqseb.41.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.0-bbqseb.41.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.0-bbqseb.41.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.0-bbqseb.41.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.0-bbqseb.41.0",
     "commit": {
       "sha": "7d318703310f9b1f3ed29d5c352a1329b7f5bc6e",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/7d318703310f9b1f3ed29d5c352a1329b7f5bc6e"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/7d318703310f9b1f3ed29d5c352a1329b7f5bc6e"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjAtYmJxc2ViLjQxLjA="
   },
   {
     "name": "v1.0.0-bbqseb.41",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v1.0.0-bbqseb.41",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v1.0.0-bbqseb.41",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v1.0.0-bbqseb.41",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v1.0.0-bbqseb.41",
     "commit": {
       "sha": "dc2392129296a3cbb4e7c9656e5b9d844c24b268",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/dc2392129296a3cbb4e7c9656e5b9d844c24b268"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/dc2392129296a3cbb4e7c9656e5b9d844c24b268"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MS4wLjAtYmJxc2ViLjQx"
   },
   {
     "name": "v0.7.7",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.7",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.7",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.7",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.7",
     "commit": {
       "sha": "26e18d506e64bc3d7cd001a7c196213f238d9706",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/26e18d506e64bc3d7cd001a7c196213f238d9706"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/26e18d506e64bc3d7cd001a7c196213f238d9706"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43Ljc="
   },
   {
     "name": "v0.7.6",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.6",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.6",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.6",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.6",
     "commit": {
       "sha": "6a7a4f44291b04bf88c141c3492da565f8ed91e6",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/6a7a4f44291b04bf88c141c3492da565f8ed91e6"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/6a7a4f44291b04bf88c141c3492da565f8ed91e6"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjY="
   },
   {
     "name": "v0.7.5",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.5",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.5",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.5",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.5",
     "commit": {
       "sha": "b5e59b6d87e9dc2b5fa3cd5fa3c1553378a6c403",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/b5e59b6d87e9dc2b5fa3cd5fa3c1553378a6c403"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/b5e59b6d87e9dc2b5fa3cd5fa3c1553378a6c403"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjU="
   },
   {
     "name": "v0.7.4",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.4",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.4",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.4",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.4",
     "commit": {
       "sha": "8bfbeac24e335ca376c71d368f1ffa1bae5348ba",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/8bfbeac24e335ca376c71d368f1ffa1bae5348ba"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/8bfbeac24e335ca376c71d368f1ffa1bae5348ba"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjQ="
   },
   {
     "name": "v0.7.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.3",
     "commit": {
       "sha": "cdbdff3c7a2c22c9deec35a8bae6ef22d5efa0b6",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/cdbdff3c7a2c22c9deec35a8bae6ef22d5efa0b6"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/cdbdff3c7a2c22c9deec35a8bae6ef22d5efa0b6"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjM="
   },
   {
     "name": "v0.7.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.2",
     "commit": {
       "sha": "3776980736f66200ee0495d941097602887b5397",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/3776980736f66200ee0495d941097602887b5397"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/3776980736f66200ee0495d941097602887b5397"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjI="
   },
   {
     "name": "v0.7.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.1",
     "commit": {
       "sha": "91df571a6f2bc217fe2e77853c07bc30530cfaaf",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/91df571a6f2bc217fe2e77853c07bc30530cfaaf"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/91df571a6f2bc217fe2e77853c07bc30530cfaaf"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjE="
   },
   {
     "name": "v0.7.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.7.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.7.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.7.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.7.0",
     "commit": {
       "sha": "aeb5b95548293b88492649d66b9486699d7b468b",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/aeb5b95548293b88492649d66b9486699d7b468b"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/aeb5b95548293b88492649d66b9486699d7b468b"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC43LjA="
   },
   {
     "name": "v0.6.6",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.6",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.6",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.6",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.6",
     "commit": {
       "sha": "46239dc02fe1d9b13ac69b1f4350f41354bed44f",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/46239dc02fe1d9b13ac69b1f4350f41354bed44f"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/46239dc02fe1d9b13ac69b1f4350f41354bed44f"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjY="
   },
   {
     "name": "v0.6.5",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.5",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.5",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.5",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.5",
     "commit": {
       "sha": "79e8b22b0b1f2b43cbf76e9f07888af08d67a612",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/79e8b22b0b1f2b43cbf76e9f07888af08d67a612"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/79e8b22b0b1f2b43cbf76e9f07888af08d67a612"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjU="
   },
   {
     "name": "v0.6.4",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.4",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.4",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.4",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.4",
     "commit": {
       "sha": "38bd15ca1fca9ce2f4c20b11b32cbd462905795f",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/38bd15ca1fca9ce2f4c20b11b32cbd462905795f"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/38bd15ca1fca9ce2f4c20b11b32cbd462905795f"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjQ="
   },
   {
     "name": "v0.6.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.3",
     "commit": {
       "sha": "532855b57925c97158a83301978800589ad8533e",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/532855b57925c97158a83301978800589ad8533e"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/532855b57925c97158a83301978800589ad8533e"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjM="
   },
   {
     "name": "v0.6.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.2",
     "commit": {
       "sha": "4d413dfbea2e5ee3dc075017b923b5cd05f3fbca",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/4d413dfbea2e5ee3dc075017b923b5cd05f3fbca"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/4d413dfbea2e5ee3dc075017b923b5cd05f3fbca"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjI="
   },
   {
     "name": "v0.6.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.1",
     "commit": {
       "sha": "76de60b1cba7d8227e40e4b34d70012f9fe8be81",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/76de60b1cba7d8227e40e4b34d70012f9fe8be81"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/76de60b1cba7d8227e40e4b34d70012f9fe8be81"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjE="
   },
   {
     "name": "v0.6.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.0",
     "commit": {
       "sha": "89c762ed1f93c7b433e597e69f6b4b006b0804c3",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/89c762ed1f93c7b433e597e69f6b4b006b0804c3"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/89c762ed1f93c7b433e597e69f6b4b006b0804c3"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjA="
   },
   {
     "name": "v0.6.0-rc.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.6.0-rc.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.6.0-rc.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.6.0-rc.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.6.0-rc.0",
     "commit": {
       "sha": "babe846edca29b3aab45ae251b90caa324729607",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/babe846edca29b3aab45ae251b90caa324729607"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/babe846edca29b3aab45ae251b90caa324729607"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC42LjAtcmMuMA=="
   },
   {
     "name": "v0.5.4",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.5.4",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.5.4",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.5.4",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.5.4",
     "commit": {
       "sha": "da34a3058e5b2cfbe903ef558d9ccb26a2238211",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/da34a3058e5b2cfbe903ef558d9ccb26a2238211"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/da34a3058e5b2cfbe903ef558d9ccb26a2238211"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC41LjQ="
   },
   {
     "name": "v0.5.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.5.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.5.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.5.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.5.3",
     "commit": {
       "sha": "d34665790e50c90e1a3287e5c4241e3d528206d6",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/d34665790e50c90e1a3287e5c4241e3d528206d6"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/d34665790e50c90e1a3287e5c4241e3d528206d6"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC41LjM="
   },
   {
     "name": "v0.5.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.5.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.5.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.5.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.5.2",
     "commit": {
       "sha": "1612ef3eb87964ea17d8a1e75396eb7d6f4ace82",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1612ef3eb87964ea17d8a1e75396eb7d6f4ace82"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1612ef3eb87964ea17d8a1e75396eb7d6f4ace82"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC41LjI="
   },
   {
     "name": "v0.5.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.5.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.5.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.5.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.5.1",
     "commit": {
       "sha": "936f66846493235ad7e945b1b1b56616386fa8e4",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/936f66846493235ad7e945b1b1b56616386fa8e4"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/936f66846493235ad7e945b1b1b56616386fa8e4"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC41LjE="
   },
   {
     "name": "v0.5.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.5.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.5.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.5.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.5.0",
     "commit": {
       "sha": "9dd973c2172291e5bb3f706d349c7d1d9fc7470b",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/9dd973c2172291e5bb3f706d349c7d1d9fc7470b"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/9dd973c2172291e5bb3f706d349c7d1d9fc7470b"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC41LjA="
   },
   {
     "name": "v0.4.12",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.12",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.12",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.12",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.12",
     "commit": {
       "sha": "20b734ba2dce6554041bb31f570031d1ce056027",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/20b734ba2dce6554041bb31f570031d1ce056027"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/20b734ba2dce6554041bb31f570031d1ce056027"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjEy"
   },
   {
     "name": "v0.4.12-rc.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.12-rc.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.12-rc.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.12-rc.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.12-rc.3",
     "commit": {
       "sha": "e8ca3dd87f0e113404ea4dea09cd28beb5023553",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/e8ca3dd87f0e113404ea4dea09cd28beb5023553"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/e8ca3dd87f0e113404ea4dea09cd28beb5023553"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjEyLXJjLjM="
   },
   {
     "name": "v0.4.12-rc.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.12-rc.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.12-rc.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.12-rc.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.12-rc.2",
     "commit": {
       "sha": "8049a962a67e502a84dfeda8c5545207ca0512a1",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/8049a962a67e502a84dfeda8c5545207ca0512a1"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/8049a962a67e502a84dfeda8c5545207ca0512a1"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjEyLXJjLjI="
   },
   {
     "name": "v0.4.12-rc.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.12-rc.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.12-rc.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.12-rc.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.12-rc.1",
     "commit": {
       "sha": "1c3fb26905871ec0edd24611b6081efe281d6cdf",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1c3fb26905871ec0edd24611b6081efe281d6cdf"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1c3fb26905871ec0edd24611b6081efe281d6cdf"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjEyLXJjLjE="
   },
   {
     "name": "v0.4.11",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.11",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.11",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.11",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.11",
     "commit": {
       "sha": "9b14d8d0cda3f701c0c2686f0ba045d14c046429",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/9b14d8d0cda3f701c0c2686f0ba045d14c046429"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/9b14d8d0cda3f701c0c2686f0ba045d14c046429"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjEx"
   },
   {
     "name": "v0.4.10",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.10",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.10",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.10",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.10",
     "commit": {
       "sha": "89acea2bf88875fde47191cfc3065781d6bde791",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/89acea2bf88875fde47191cfc3065781d6bde791"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/89acea2bf88875fde47191cfc3065781d6bde791"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjEw"
   },
   {
     "name": "v0.4.9",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.9",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.9",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.9",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.9",
     "commit": {
       "sha": "cc74f4174d7625d52ba65f7eac38a0c59cc51ec0",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/cc74f4174d7625d52ba65f7eac38a0c59cc51ec0"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/cc74f4174d7625d52ba65f7eac38a0c59cc51ec0"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40Ljk="
   },
   {
     "name": "v0.4.8",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.8",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.8",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.8",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.8",
     "commit": {
       "sha": "ad11c6bbe89c02491372b6444d47fe6e35cd791f",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ad11c6bbe89c02491372b6444d47fe6e35cd791f"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ad11c6bbe89c02491372b6444d47fe6e35cd791f"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40Ljg="
   },
   {
     "name": "v0.4.7",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.7",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.7",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.7",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.7",
     "commit": {
       "sha": "2e48a6819f164b99fee3ad04ab1ea99372a86a7c",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/2e48a6819f164b99fee3ad04ab1ea99372a86a7c"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/2e48a6819f164b99fee3ad04ab1ea99372a86a7c"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40Ljc="
   },
   {
     "name": "v0.4.6",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.6",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.6",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.6",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.6",
     "commit": {
       "sha": "22c28e0557fda9b905f4c056cabaa07cb0e09662",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/22c28e0557fda9b905f4c056cabaa07cb0e09662"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/22c28e0557fda9b905f4c056cabaa07cb0e09662"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjY="
   },
   {
     "name": "v0.4.5",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.5",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.5",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.5",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.5",
     "commit": {
       "sha": "1ff4880f8cef05e962b4b220e7437ea906beda30",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1ff4880f8cef05e962b4b220e7437ea906beda30"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1ff4880f8cef05e962b4b220e7437ea906beda30"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjU="
   },
   {
     "name": "v0.4.5-rc.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.5-rc.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.5-rc.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.5-rc.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.5-rc.2",
     "commit": {
       "sha": "ebe14aca23612a61ba3b59d0c2a4b593aefb1f85",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/ebe14aca23612a61ba3b59d0c2a4b593aefb1f85"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/ebe14aca23612a61ba3b59d0c2a4b593aefb1f85"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjUtcmMuMg=="
   },
   {
     "name": "v0.4.4",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.4",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.4",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.4",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.4",
     "commit": {
       "sha": "3301aa5a1c24df212002eece0d28eb98e47545e4",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/3301aa5a1c24df212002eece0d28eb98e47545e4"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/3301aa5a1c24df212002eece0d28eb98e47545e4"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjQ="
   },
   {
     "name": "v0.4.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.3",
     "commit": {
       "sha": "30032407d147184aa8a105d6e331b6582859708f",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/30032407d147184aa8a105d6e331b6582859708f"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/30032407d147184aa8a105d6e331b6582859708f"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjM="
   },
   {
     "name": "v0.4.2",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.2",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.2",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.2",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.2",
     "commit": {
       "sha": "5dc594ab84e645919adf9ba12cbdcadbd40140a2",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/5dc594ab84e645919adf9ba12cbdcadbd40140a2"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/5dc594ab84e645919adf9ba12cbdcadbd40140a2"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjI="
   },
   {
     "name": "v0.4.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.1",
     "commit": {
       "sha": "f01a26ef61fe9e9a8a23bf74543711e73fce5864",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/f01a26ef61fe9e9a8a23bf74543711e73fce5864"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/f01a26ef61fe9e9a8a23bf74543711e73fce5864"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjE="
   },
   {
     "name": "v0.4.0",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.4.0",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.4.0",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.4.0",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.4.0",
     "commit": {
       "sha": "79f7ea33b23531471f88b545eddba1bddd40c02c",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/79f7ea33b23531471f88b545eddba1bddd40c02c"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/79f7ea33b23531471f88b545eddba1bddd40c02c"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC40LjA="
   },
   {
     "name": "v0.3.8",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.3.8",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.3.8",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.3.8",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.3.8",
     "commit": {
       "sha": "8c6fa7460b9ad62da14cf7342a23295c32d43454",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/8c6fa7460b9ad62da14cf7342a23295c32d43454"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/8c6fa7460b9ad62da14cf7342a23295c32d43454"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC4zLjg="
   },
   {
     "name": "v0.3.7",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.3.7",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.3.7",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.3.7",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.3.7",
     "commit": {
       "sha": "e7eb70f8b16d37d47f42018308b329442de478ec",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/e7eb70f8b16d37d47f42018308b329442de478ec"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/e7eb70f8b16d37d47f42018308b329442de478ec"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC4zLjc="
   },
   {
     "name": "v0.3.6",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.3.6",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.3.6",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.3.6",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.3.6",
     "commit": {
       "sha": "539dd1fc3f2aa2e06f03848a072d1b4d041dbe29",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/539dd1fc3f2aa2e06f03848a072d1b4d041dbe29"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/539dd1fc3f2aa2e06f03848a072d1b4d041dbe29"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC4zLjY="
   },
   {
     "name": "v0.3.5",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.3.5",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.3.5",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.3.5",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.3.5",
     "commit": {
       "sha": "915df9dcb69d75ed4cb1039cc9c9491703d6c567",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/915df9dcb69d75ed4cb1039cc9c9491703d6c567"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/915df9dcb69d75ed4cb1039cc9c9491703d6c567"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC4zLjU="
   },
   {
     "name": "v0.2.1",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/v0.2.1",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/v0.2.1",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/v0.2.1",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/v0.2.1",
     "commit": {
       "sha": "4333fda0d13b7c7475cf96f27b1601a976ed62ac",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/4333fda0d13b7c7475cf96f27b1601a976ed62ac"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/4333fda0d13b7c7475cf96f27b1601a976ed62ac"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy92MC4yLjE="
   },
   {
     "name": "push",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/push",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/push",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/push",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/push",
     "commit": {
       "sha": "0964f9734069b4b2cd02df45eff569cc26d4b209",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/0964f9734069b4b2cd02df45eff569cc26d4b209"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/0964f9734069b4b2cd02df45eff569cc26d4b209"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy9wdXNo"
   },
   {
     "name": "core-0.3.3",
-    "zipball_url": "https://api.github.com/repos/SAP/luigi/zipball/refs/tags/core-0.3.3",
-    "tarball_url": "https://api.github.com/repos/SAP/luigi/tarball/refs/tags/core-0.3.3",
+    "zipball_url": "https://api.github.com/repos/luigi-project/luigi/zipball/refs/tags/core-0.3.3",
+    "tarball_url": "https://api.github.com/repos/luigi-project/luigi/tarball/refs/tags/core-0.3.3",
     "commit": {
       "sha": "1a93509fa93dcd23a786cbfffb4b1cd460ff0ef6",
-      "url": "https://api.github.com/repos/SAP/luigi/commits/1a93509fa93dcd23a786cbfffb4b1cd460ff0ef6"
+      "url": "https://api.github.com/repos/luigi-project/luigi/commits/1a93509fa93dcd23a786cbfffb4b1cd460ff0ef6"
     },
     "node_id": "MDM6UmVmMTM5NTkwNzAxOnJlZnMvdGFncy9jb3JlLTAuMy4z"
   }

--- a/website/fiddle/src/defaultConfig.js
+++ b/website/fiddle/src/defaultConfig.js
@@ -154,7 +154,7 @@ Luigi.setConfig({
                 },{
                     label: 'Luigi Github Page',
                     externalLink : { 
-                        url: 'https://github.com/SAP/luigi'
+                        url: 'https://github.com/luigi-project/luigi'
                     }
                 },{
                     label: 'Fundamental Library',
@@ -170,7 +170,7 @@ Luigi.setConfig({
             }],
             productSwitcher: {
                 items: [{
-                    icon: 'https://raw.githubusercontent.com/SAP/luigi/main/website/landingpage/public/assets/img/logos/sap.svg',
+                    icon: 'https://raw.githubusercontent.com/luigi-project/luigi/main/website/landingpage/public/assets/img/logos/sap.svg',
                     label: 'SAP homepage',
                     externalLink: {
                       url: 'https://www.sap.com',

--- a/website/landingpage/dev/src/partials/error-page-content.html
+++ b/website/landingpage/dev/src/partials/error-page-content.html
@@ -28,7 +28,7 @@
           <a href="https://slack.luigi-project.io" target="blank">Continue to Slack</a>
         </li>
         <li class="item">
-          <a href="https://github.com/SAP/luigi" target="blank">Continue to GitHub</a>
+          <a href="https://github.com/luigi-project/luigi" target="blank">Continue to GitHub</a>
         </li>
       </ul>
     </div>

--- a/website/landingpage/dev/src/partials/global-nav.html
+++ b/website/landingpage/dev/src/partials/global-nav.html
@@ -29,7 +29,7 @@
             class="icon-slack-icon"></a>
         </li>
         <li class="item">
-          <a href="https://github.com/SAP/luigi" target="_blank" rel="noopener noreferrer" class="icon-github-icon"></a>
+          <a href="https://github.com/luigi-project/luigi" target="_blank" rel="noopener noreferrer" class="icon-github-icon"></a>
         </li>
       </ul>
     </nav>

--- a/website/landingpage/dev/src/partials/whoisusingluigi.html
+++ b/website/landingpage/dev/src/partials/whoisusingluigi.html
@@ -36,7 +36,7 @@
                 src="/assets/img/logos/medirect.svg" alt="medirect" /></a>
     </li>
     <li class="item add-your-company">
-        <a href="https://github.com/SAP/luigi/blob/main/website/landingpage/dev/src/partials/whoisusingluigi.html"
+        <a href="https://github.com/luigi-project/luigi/blob/main/website/landingpage/dev/src/partials/whoisusingluigi.html"
             target="_blank" rel="noopener noreferrer">Your Company</a>
     </li>
 </ul>


### PR DESCRIPTION


Changes proposed in this pull request:

change links in repo from "github.com/SAP/luigi" to "github.com/luigi-project/luigi"

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #4303 
