### PR TITLE
Fix empty app switcher data runtime error

### DIFF
--- a/core-modular/src/utilities/helpers/navigation-helpers.ts
+++ b/core-modular/src/utilities/helpers/navigation-helpers.ts
@@ -47,7 +47,7 @@ export const NavigationHelpers = {
   },
 
   updateHeaderTitle: (appSwitcherData: AppSwitcher, pathData: PathData): String | undefined => {
-    const appSwitcherItems = appSwitcherData.items;
+    const appSwitcherItems = appSwitcherData?.items;
     if (appSwitcherItems && pathData) {
       let title = '';
       [...appSwitcherItems]


### PR DESCRIPTION
When appSwitcherData is undefined, this produces a runtime error, due to access to `appSwitcherData.items`