### PR TITLE
fix: handle undefined iframe in sendMessage method

### DIFF
--- a/core/src/utilities/helpers/iframe-helpers.js
+++ b/core/src/utilities/helpers/iframe-helpers.js
@@ -167,7 +167,7 @@ class IframeHelpersClass {
   }
 
   sendMessageToIframe(iframe, message) {
-    if (!(iframe.luigi && iframe.luigi.viewUrl && iframe._ready)) {
+    if (!(iframe && iframe.luigi && iframe.luigi.viewUrl && iframe._ready)) {
       return;
     }
     const trustedIframeDomain = this.getLocation(iframe.luigi.viewUrl);


### PR DESCRIPTION
we see in our sentry that this method is throwing `undefined is not an object (evaluating 'e.luigi')`
