### PR TITLE
container-release v1.7.2

### DIFF
--- a/container/CHANGELOG.md
+++ b/container/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 
 
+## [v1.7.2] (2025-08-14)
+
+#### :bug: Fixed
+
+* [#4438](https://github.com/luigi-project/luigi/pull/4438) Fix: LuigiContainer should not be initialized if no view url ([@JohannesDoberer](https://github.com/JohannesDoberer))
+
+
+
+
+
 ## [v1.7.1] (2025-08-06)
 
 #### :bug: Fixed
@@ -108,3 +118,4 @@
 [v1.6.0]: https://github.com/luigi-project/luigi/compare/container/v1.5.0...container/v1.6.0
 [v1.7.0]: https://github.com/luigi-project/luigi/compare/container/v1.6.0...container/v1.7.0
 [v1.7.1]: https://github.com/luigi-project/luigi/compare/container/v1.7.0...container/v1.7.1
+[v1.7.2]: https://github.com/luigi-project/luigi/compare/container/v1.7.1...container/v1.7.2

--- a/container/public/package.json
+++ b/container/public/package.json
@@ -20,5 +20,5 @@
         "micro-frontends",
         "microfrontends"
     ],
-    "version": "1.7.1"
+    "version": "1.7.2"
 }


### PR DESCRIPTION
## [v1.7.2] (2025-08-14)

#### :bug: Fixed

* [#4438](https://github.com/luigi-project/luigi/pull/4438) Fix: LuigiContainer should not be initialized if no view url ([@JohannesDoberer](https://github.com/JohannesDoberer))
