### PR TITLE
Fix/category without label

### DIFF
--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -358,6 +358,8 @@ export const UIModule = {
       }
 
       if (viewGroupContainer) {
+        const previousViewUrl = viewGroupContainer.viewurl;
+
         if (!withoutSync) {
           viewGroupContainer.style.display = 'block';
           viewGroupContainer.viewurl = resolvedViewUrl;
@@ -377,7 +379,12 @@ export const UIModule = {
 
         if (!preventContextUpdate) {
           //IMPORTANT!!! This needs to be at the end
-          viewGroupContainer.updateContext(currentNode.context || {}, { withoutSync: false });
+          if (previousViewUrl !== resolvedViewUrl) {
+            viewGroupContainer.context = currentNode.context || {};
+            viewGroupContainer.updateViewUrl(resolvedViewUrl);
+          } else {
+            viewGroupContainer.updateContext(currentNode.context || {}, { withoutSync: false });
+          }
         }
       } else {
         const container = await createContainer(currentNode, luigi, luigiParams, 'main');

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -379,7 +379,10 @@ export const UIModule = {
 
         if (!preventContextUpdate) {
           //IMPORTANT!!! This needs to be at the end
-          if (previousViewUrl !== resolvedViewUrl) {
+          const hashChanged =
+            GenericHelpers.isSameUrl(previousViewUrl, resolvedViewUrl) && previousViewUrl !== resolvedViewUrl;
+
+          if (hashChanged && !viewGroupContainer.virtualTree) {
             viewGroupContainer.context = currentNode.context || {};
             viewGroupContainer.updateViewUrl(resolvedViewUrl);
           } else {

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -253,10 +253,10 @@ export class NavigationService {
         nodeHref = externalLink.url;
       }
 
-      const hasMeaningfulCategory =
+      const isCategoryValid =
         node.category && (typeof node.category === 'string' || node.category.id || node.category.label);
 
-      if (hasMeaningfulCategory) {
+      if (isCategoryValid) {
         const catId = node.category.id || node.category.label || node.category;
         const catLabel = this.luigi.i18n().getTranslation(node.category.label || node.category.id || node.category);
         let catNode: NavItem = catMap[catId];
@@ -301,7 +301,7 @@ export class NavigationService {
           tooltip: node.label ? this.resolveTooltipText(node, node.label) : undefined
         });
       } else {
-        items.push({
+        const navItem = {
           altText: node.altText,
           badgeCounter: node.badgeCounter,
           externalLink,
@@ -311,7 +311,13 @@ export class NavigationService {
           node,
           selected: node === selectedNode,
           tooltip: node.label ? this.resolveTooltipText(node, node.label) : undefined
-        });
+        };
+
+        if (node.category && !isCategoryValid) {
+          items.unshift(navItem);
+        } else {
+          items.push(navItem);
+        }
       }
 
       if (badgeCount) {

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -253,7 +253,10 @@ export class NavigationService {
         nodeHref = externalLink.url;
       }
 
-      if (node.category) {
+      const hasMeaningfulCategory =
+        node.category && (typeof node.category === 'string' || node.category.id || node.category.label);
+
+      if (hasMeaningfulCategory) {
         const catId = node.category.id || node.category.label || node.category;
         const catLabel = this.luigi.i18n().getTranslation(node.category.label || node.category.id || node.category);
         let catNode: NavItem = catMap[catId];

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -216,6 +216,7 @@ export class NavigationService {
   }> {
     const catMap: Record<string, NavItem> = {};
     const items: NavItem[] = [];
+    const orphanItems: NavItem[] = [];
     const badgeCountsToSumUp: number[] = [];
 
     for (const node of nodes) {
@@ -314,7 +315,7 @@ export class NavigationService {
         };
 
         if (node.category && !isCategoryValid) {
-          items.unshift(navItem);
+          orphanItems.push(navItem);
         } else {
           items.push(navItem);
         }
@@ -330,6 +331,8 @@ export class NavigationService {
       count: () => badgeCountSum,
       label: ''
     };
+
+    items.unshift(...orphanItems);
 
     return { items, totalBadgeNode };
   }

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -1246,6 +1246,62 @@ describe('NavigationService', () => {
       expect(data.items[0].href).toBe('#/settings');
       jest.restoreAllMocks();
     });
+    it('should preserve insertion order for items with invalid category', async () => {
+      const invalidCategory = { id: '', label: '' };
+      const nodeA: Node = { pathSegment: 'a', label: 'A', category: invalidCategory, children: [] };
+      const nodeB: Node = { pathSegment: 'b', label: 'B', category: invalidCategory, children: [] };
+      const nodeC: Node = { pathSegment: 'c', label: 'C', category: invalidCategory, children: [] };
+      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
+      const pathData = {
+        selectedNode: undefined,
+        selectedNodeChildren: [nodeA, nodeB, nodeC],
+        nodesInPath: [],
+        rootNodes: [nodeA, nodeB, nodeC],
+        pathParams: {}
+      };
+      const data = await navigationService.buildNavItems([nodeA, nodeB, nodeC], undefined, pathData, true);
+      expect(data.items.map((i: any) => i.label)).toEqual(['A', 'B', 'C']);
+    });
+
+    it('should place invalid-category items before regular items', async () => {
+      const invalidCategory = { id: '', label: '' };
+      const orphanNode: Node = { pathSegment: 'orphan', label: 'Orphan', category: invalidCategory, children: [] };
+      const regularNode: Node = { pathSegment: 'regular', label: 'Regular', children: [] };
+      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
+      const pathData = {
+        selectedNode: undefined,
+        selectedNodeChildren: [regularNode, orphanNode],
+        nodesInPath: [],
+        rootNodes: [regularNode, orphanNode],
+        pathParams: {}
+      };
+      const data = await navigationService.buildNavItems([regularNode, orphanNode], undefined, pathData, true);
+      expect(data.items[0].label).toBe('Orphan');
+      expect(data.items[1].label).toBe('Regular');
+    });
+
+    it('should place multiple invalid-category items before categorized and regular items in order', async () => {
+      const invalidCategory = { id: '', label: '' };
+      const validCategory = { id: 'cat1', label: 'Cat 1' };
+      const orphanA: Node = { pathSegment: 'oa', label: 'OrphanA', category: invalidCategory, children: [] };
+      const catNode: Node = { pathSegment: 'cn', label: 'CatNode', category: validCategory, children: [] };
+      const orphanB: Node = { pathSegment: 'ob', label: 'OrphanB', category: invalidCategory, children: [] };
+      const regularNode: Node = { pathSegment: 'rn', label: 'Regular', children: [] };
+      luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
+      const nodes = [orphanA, catNode, orphanB, regularNode];
+      const pathData = {
+        selectedNode: undefined,
+        selectedNodeChildren: nodes,
+        nodesInPath: [],
+        rootNodes: nodes,
+        pathParams: {}
+      };
+      const data = await navigationService.buildNavItems(nodes, undefined, pathData, true);
+      expect(data.items[0].label).toBe('OrphanA');
+      expect(data.items[1].label).toBe('OrphanB');
+      expect(data.items[2].category?.id).toBe('cat1');
+      expect(data.items[3].label).toBe('Regular');
+    });
   });
 
   describe('NavigationService.getChildren', () => {

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -1252,14 +1252,15 @@ describe('NavigationService', () => {
       const nodeB: Node = { pathSegment: 'b', label: 'B', category: invalidCategory, children: [] };
       const nodeC: Node = { pathSegment: 'c', label: 'C', category: invalidCategory, children: [] };
       luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
-      const pathData = {
+      const pathData: PathData = {
         selectedNode: undefined,
         selectedNodeChildren: [nodeA, nodeB, nodeC],
         nodesInPath: [],
         rootNodes: [nodeA, nodeB, nodeC],
-        pathParams: {}
+        pathParams: {},
+        matchedPath: ''
       };
-      const data = await navigationService.buildNavItems([nodeA, nodeB, nodeC], undefined, pathData, true);
+      const data = await navigationService.buildNavItems([nodeA, nodeB, nodeC], undefined, pathData);
       expect(data.items.map((i: any) => i.label)).toEqual(['A', 'B', 'C']);
     });
 
@@ -1268,14 +1269,15 @@ describe('NavigationService', () => {
       const orphanNode: Node = { pathSegment: 'orphan', label: 'Orphan', category: invalidCategory, children: [] };
       const regularNode: Node = { pathSegment: 'regular', label: 'Regular', children: [] };
       luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
-      const pathData = {
+      const pathData: PathData = {
         selectedNode: undefined,
         selectedNodeChildren: [regularNode, orphanNode],
         nodesInPath: [],
         rootNodes: [regularNode, orphanNode],
-        pathParams: {}
+        pathParams: {},
+        matchedPath: ''
       };
-      const data = await navigationService.buildNavItems([regularNode, orphanNode], undefined, pathData, true);
+      const data = await navigationService.buildNavItems([regularNode, orphanNode], undefined, pathData);
       expect(data.items[0].label).toBe('Orphan');
       expect(data.items[1].label).toBe('Regular');
     });
@@ -1289,14 +1291,15 @@ describe('NavigationService', () => {
       const regularNode: Node = { pathSegment: 'rn', label: 'Regular', children: [] };
       luigiMock.i18n = jest.fn().mockReturnValue({ getTranslation: (key: string) => key });
       const nodes = [orphanA, catNode, orphanB, regularNode];
-      const pathData = {
+      const pathData: PathData = {
         selectedNode: undefined,
         selectedNodeChildren: nodes,
         nodesInPath: [],
         rootNodes: nodes,
-        pathParams: {}
+        pathParams: {},
+        matchedPath: ''
       };
-      const data = await navigationService.buildNavItems(nodes, undefined, pathData, true);
+      const data = await navigationService.buildNavItems(nodes, undefined, pathData);
       expect(data.items[0].label).toBe('OrphanA');
       expect(data.items[1].label).toBe('OrphanB');
       expect(data.items[2].category?.id).toBe('cat1');


### PR DESCRIPTION
## Fix category handling and iframe navigation for same-URL nodes

### Summary
- Fix nodes with invalid category objects (no `label` and no `id`) being rendered as broken category groups instead of flat navigation items
- Fix iframe content not updating when navigating between nodes that share the same base URL but differ only in the hash fragment
- Nodes with an invalid category are placed at the beginning of the left nav items list (matching old core behavior)

### Changes

**`navigation.service.ts`**
- A category is now only treated as valid if it is a string or an object with `id` or `label`. Otherwise the node renders as a standalone item.
- Nodes with an invalid category object are unshifted to the front of the items array.

**`ui-module.ts`**
- When reusing an existing container (same base URL, determined by `isSameUrl`), the previous `viewUrl` is now compared against the resolved one. If the URL changed (e.g. different hash), `updateViewUrl()` is called to notify the iframe of the new route. Previously only `updateContext()` was called, which does not propagate the `viewUrl` to the microfrontend.

### Test plan
- [ ] Configure a node with `category: { icon: 'group' }` (no label/id) → should render as a flat item at the top of the left nav
- [ ] Configure two sibling nodes with same base URL but different hashes (e.g. `/mfe.html#child3` and `/mfe.html#child4`) without `viewGroup` → clicking between them should update the iframe content
