### PR TITLE
tab-nav options

### DIFF
--- a/core-modular/dev-tools/templates/simple/luigi-config.js
+++ b/core-modular/dev-tools/templates/simple/luigi-config.js
@@ -234,6 +234,26 @@ window.onload = () => {
               webcomponent: true
             },
             {
+              pathSegment: 'wctabs',
+              label: 'WC Tabs',
+              viewUrl: '/helloWorldWC.js',
+              tabNav: { showAsTabHeader: true },
+              webcomponent: true,
+              children: [
+                {
+                  pathSegment: 'wctabschild1',
+                  label: 'WC Tab Child 1',
+                  viewUrl: '/helloWorldWC.js',
+                  webcomponent: true
+                },
+                {
+                  pathSegment: 'wctabschild2',
+                  label: 'WC Tab Child 2',
+                  viewUrl: '/microfrontend.html#wctabchild2'
+                }
+              ]
+            },
+            {
               pathSegment: 'c3',
               label: 'MFE3',
               icon: 'group',

--- a/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
+++ b/core-modular/dev-tools/templates/simple/luigi-ui/lui-ui5wc.js
@@ -1058,9 +1058,41 @@ const connector = {
 
   renderTabNav: (tabNavData) => {
     const tabcontainer = document.querySelector('ui5-tabcontainer');
+    let tabHeaderContainer = document.querySelector('.lui-tab-header');
     tabcontainer?.setAttribute('no-auto-selection', '');
     if (tabcontainer) tabcontainer.innerHTML = '';
-    if (Object.keys(tabNavData).length === 0) {
+
+    // Handle tab header web component
+    if (tabNavData.headerNode) {
+      if (!tabHeaderContainer) {
+        tabHeaderContainer = document.createElement('div');
+        tabHeaderContainer.className = 'lui-tab-header';
+        tabcontainer?.parentElement?.insertBefore(tabHeaderContainer, tabcontainer);
+      }
+      tabHeaderContainer.classList.add('lui-tab-header--active');
+      const existingLc = tabHeaderContainer.querySelector('luigi-container');
+      if (existingLc && existingLc.getAttribute('viewurl') === tabNavData.headerNode.viewUrl) {
+        // Update context on existing container
+        existingLc.context = tabNavData.headerNode.context || {};
+      } else {
+        // Create new container
+        tabHeaderContainer.innerHTML = '';
+        const lc = document.createElement('luigi-container');
+        lc.setAttribute('viewurl', tabNavData.headerNode.viewUrl);
+        lc.setAttribute('webcomponent', 'true');
+        lc.setAttribute('skipInitCheck', 'true');
+        lc.setAttribute('noShadow', 'true');
+        if (tabNavData.headerNode.context) {
+          lc.context = tabNavData.headerNode.context;
+        }
+        tabHeaderContainer.appendChild(lc);
+      }
+    } else if (tabHeaderContainer) {
+      tabHeaderContainer.innerHTML = '';
+      tabHeaderContainer.classList.remove('lui-tab-header--active');
+    }
+
+    if (Object.keys(tabNavData).length === 0 || !tabNavData.items?.length) {
       document.querySelector('.content-wrapper > ui5-tabcontainer')?.classList.add('ui5-tabcontainer-hidden');
       return;
     }

--- a/core-modular/dev-tools/templates/simple/luigi-ui/lui.css
+++ b/core-modular/dev-tools/templates/simple/luigi-ui/lui.css
@@ -27,6 +27,14 @@ ui5-side-navigation {
     display: none;
 }
 
+.lui-tab-header {
+    display: none;
+}
+
+.lui-tab-header--active {
+    display: block;
+}
+
 .lui-dialog::part(header),
 .lui-dialog::part(footer) {
   padding-inline: 0;

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -749,6 +749,10 @@ export class NavigationService {
     const tabNavNode = parentNode || selectedNode;
     const tabNavConfig = this.getTabNavConfig(tabNavNode);
 
+    if (tabNavConfig && !('hideTabNavAutomatically' in tabNavConfig) && !tabNavConfig.showAsTabHeader) {
+      console.warn('tabNav:{hideTabNavAutomatically:true|false} is not configured correctly.');
+    }
+
     let basePath = '';
     pathData.nodesInPath?.forEach((nip) => {
       if (nip.children) {

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -23,6 +23,7 @@ import type {
   ProductSwitcherItem,
   ProfileItem,
   ProfileSettings,
+  TabNavConfig,
   TabNavData,
   TopNavData,
   UserInfo,
@@ -744,6 +745,10 @@ export class NavigationService {
       parentNode = this.getParentNode(selectedNode, pathData) as Node;
       if (parentNode && !parentNode.tabNav) return {};
     }
+
+    const tabNavNode = parentNode || selectedNode;
+    const tabNavConfig = this.getTabNavConfig(tabNavNode);
+
     let basePath = '';
     pathData.nodesInPath?.forEach((nip) => {
       if (nip.children) {
@@ -751,18 +756,39 @@ export class NavigationService {
       }
     });
 
-    const pathDataTruncatedChildren = parentNode
+    const children = parentNode
       ? this.getTruncatedChildren(parentNode.children ?? [])
       : this.getTruncatedChildren(selectedNode.children ?? []);
-    const navData = await this.buildNavItems(pathDataTruncatedChildren, selectedNode, pathData);
 
-    return {
+    if (tabNavConfig?.hideTabNavAutomatically && children.length <= 1) {
+      return {};
+    }
+
+    const navData = await this.buildNavItems(children, selectedNode, pathData);
+
+    const result: TabNavData = {
       selectedNode,
       items: navData.items,
       totalBadgeNode: navData.totalBadgeNode,
       basePath: basePath.replace(/\/\/+/g, '/'),
       navClick: (item: NavItem) => (item.node ? this.navItemClick(item.node, pathData) : Promise.resolve())
     };
+
+    if (tabNavConfig?.showAsTabHeader && tabNavNode.webcomponent && tabNavNode.viewUrl) {
+      result.headerNode = {
+        viewUrl: tabNavNode.viewUrl,
+        context: pathData.context || tabNavNode.context,
+        webcomponent: tabNavNode.webcomponent
+      };
+    }
+
+    return result;
+  }
+
+  private getTabNavConfig(node: Node): TabNavConfig | undefined {
+    if (!node.tabNav) return undefined;
+    if (typeof node.tabNav === 'object') return node.tabNav as TabNavConfig;
+    return undefined;
   }
 
   async getBreadcrumbData(
@@ -1416,7 +1442,7 @@ export class NavigationService {
    * @param options.fromContext - If set, returns the path relative to the ancestor whose `navigationContext` matches this value.
    * @returns The current route path relative to the resolved context node, or the full sub-path if no option is set.
    */
-  async getCurrentRoutePath(options: NavigationOptions): Promise<string|undefined> {
+  async getCurrentRoutePath(options: NavigationOptions): Promise<string | undefined> {
     const { fromVirtualTreeRoot, fromContext, fromClosestContext, fromParent } = options;
     const hashRouting = this.luigi.getConfigValue('routing.useHashRouting');
     const { path: currentPath, query } = RoutingHelpers.getCurrentPath(this.luigi, hashRouting);

--- a/core-modular/src/types/navigation.ts
+++ b/core-modular/src/types/navigation.ts
@@ -172,7 +172,7 @@ export interface Node {
   pathSegment?: string;
   runTimeErrorHandler?: RunTimeErrorHandler;
   showBreadcrumbs?: boolean;
-  tabNav?: boolean;
+  tabNav?: boolean | TabNavConfig;
   titleResolver?: TitleResolver;
   tooltipText?: string;
   userSettingsGroup?: string;
@@ -237,8 +237,18 @@ export interface NavItem {
   tooltip?: string;
 }
 
+export interface TabNavConfig {
+  showAsTabHeader?: boolean;
+  hideTabNavAutomatically?: boolean;
+}
+
 export interface TabNavData {
   basePath?: string;
+  headerNode?: {
+    viewUrl: string;
+    context?: Record<string, any>;
+    webcomponent?: boolean | { type?: string; selfRegistered?: boolean; tagName?: string };
+  };
   items?: NavItem[];
   navClick?: (item: NavItem) => Promise<void>;
   selectedNode?: any;

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -2578,6 +2578,73 @@ describe('NavigationService', () => {
       expect(result.headerNode!.context).toEqual({ dynamic: 'route-context' });
     });
 
+    it('should log console.warn when tabNav is an object without hideTabNavAutomatically or showAsTabHeader', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: {} as any,
+        viewUrl: '/tabs.html',
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(warnSpy).toHaveBeenCalledWith('tabNav:{hideTabNavAutomatically:true|false} is not configured correctly.');
+      warnSpy.mockRestore();
+    });
+
+    it('should not log console.warn when tabNav has hideTabNavAutomatically', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { hideTabNavAutomatically: true },
+        viewUrl: '/tabs.html',
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should not log console.warn when tabNav has showAsTabHeader', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { showAsTabHeader: true },
+        viewUrl: 'http://localhost/header.js',
+        webcomponent: true,
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
     it('should fall back to tabNavNode.context when pathData.context is falsy', async () => {
       const tabNode: Node = {
         pathSegment: 'tabs',

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -2375,4 +2375,229 @@ describe('NavigationService', () => {
       expect(result).toEqual(undefined);
     });
   });
+
+  describe('NavigationService.getTabNavData', () => {
+    const childNode1: Node = { pathSegment: 'child1', label: 'Child 1', viewUrl: '/child1.html', children: [] };
+    const childNode2: Node = { pathSegment: 'child2', label: 'Child 2', viewUrl: '/child2.html', children: [] };
+
+    beforeEach(() => {
+      luigiMock.i18n = jest.fn().mockReturnValue({
+        getTranslation: jest.fn((key: string) => key)
+      });
+    });
+
+    it('should return empty object when path is empty and root has viewUrl', async () => {
+      const pathData: PathData = {
+        nodesInPath: [{ pathSegment: '', viewUrl: '/root.html', children: [] }],
+        selectedNode: { pathSegment: '', viewUrl: '/root.html', children: [] },
+        pathParams: {},
+        context: {}
+      };
+      jest.spyOn(navigationService, 'getPathData').mockResolvedValue(pathData);
+
+      const result = await navigationService.getTabNavData('', pathData);
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when selectedNode is undefined', async () => {
+      const pathData: PathData = {
+        nodesInPath: [],
+        selectedNode: undefined,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/nonexistent', pathData);
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object when neither node nor parent has tabNav', async () => {
+      const parentNode: Node = { pathSegment: 'parent', label: 'Parent', children: [childNode1] };
+      childNode1.parent = parentNode;
+      const pathData: PathData = {
+        nodesInPath: [parentNode, childNode1],
+        selectedNode: childNode1,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/parent/child1', pathData);
+      expect(result).toEqual({});
+    });
+
+    it('should return tab nav data when selectedNode has tabNav: true', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: true,
+        viewUrl: '/tabs.html',
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(result.selectedNode).toBe(tabNode);
+      expect(result.items).toBeDefined();
+      expect(result.basePath).toBeDefined();
+      expect(result.navClick).toBeInstanceOf(Function);
+    });
+
+    it('should return tab nav data when parent has tabNav: true', async () => {
+      const parentNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: true,
+        children: [childNode1, childNode2]
+      };
+      childNode1.parent = parentNode;
+      const pathData: PathData = {
+        nodesInPath: [parentNode, childNode1],
+        selectedNode: childNode1,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/tabs/child1', pathData);
+
+      expect(result.selectedNode).toBe(childNode1);
+      expect(result.items).toBeDefined();
+      expect(result.navClick).toBeInstanceOf(Function);
+    });
+
+    it('should return empty object when hideTabNavAutomatically is true and only 1 child', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { hideTabNavAutomatically: true },
+        viewUrl: '/tabs.html',
+        children: [childNode1]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+      expect(result).toEqual({});
+    });
+
+    it('should return tab nav data when hideTabNavAutomatically is true but more than 1 child', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { hideTabNavAutomatically: true },
+        viewUrl: '/tabs.html',
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(result.selectedNode).toBe(tabNode);
+      expect(result.items).toBeDefined();
+      expect(result.items!.length).toBeGreaterThan(0);
+    });
+
+    it('should include headerNode when showAsTabHeader is true and node is a webcomponent', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { showAsTabHeader: true },
+        viewUrl: 'http://localhost/header.js',
+        webcomponent: true,
+        context: { title: 'Header' },
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: { title: 'Current Context' }
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(result.headerNode).toBeDefined();
+      expect(result.headerNode!.viewUrl).toBe('http://localhost/header.js');
+      expect(result.headerNode!.webcomponent).toBe(true);
+      expect(result.headerNode!.context).toEqual({ title: 'Current Context' });
+    });
+
+    it('should not include headerNode when showAsTabHeader is true but node is not a webcomponent', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { showAsTabHeader: true },
+        viewUrl: '/tabs.html',
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: {}
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(result.headerNode).toBeUndefined();
+    });
+
+    it('should use pathData.context for headerNode context', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { showAsTabHeader: true },
+        viewUrl: 'http://localhost/header.js',
+        webcomponent: true,
+        context: { static: 'node-context' },
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: { dynamic: 'route-context' }
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(result.headerNode!.context).toEqual({ dynamic: 'route-context' });
+    });
+
+    it('should fall back to tabNavNode.context when pathData.context is falsy', async () => {
+      const tabNode: Node = {
+        pathSegment: 'tabs',
+        label: 'Tabs',
+        tabNav: { showAsTabHeader: true },
+        viewUrl: 'http://localhost/header.js',
+        webcomponent: true,
+        context: { fallback: 'node-context' },
+        children: [childNode1, childNode2]
+      };
+      const pathData: PathData = {
+        nodesInPath: [tabNode],
+        selectedNode: tabNode,
+        pathParams: {},
+        context: undefined as any
+      };
+
+      const result = await navigationService.getTabNavData('/tabs', pathData);
+
+      expect(result.headerNode!.context).toEqual({ fallback: 'node-context' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds `TabNavConfig` options to core-modular's tab navigation, enabling two new behaviors:

- **`hideTabNavAutomatically`** — Hides the tab navigation bar when a node has ≤1 visible child, reducing UI clutter for single-child routes.
- **`showAsTabHeader`** — Renders the tab nav node's own `viewUrl` as a web component header above the tabs. Useful for displaying a summary/dashboard component while still offering tab-based child navigation below it.

## Changes

- **`core-modular/src/types/navigation.ts`** — Extended `tabNav` from `boolean` to `boolean | TabNavConfig`; added `TabNavConfig` interface and `headerNode` to `TabNavData`
- **`core-modular/src/services/navigation.service.ts`** — Implemented `getTabNavConfig()` helper; updated `getTabNavData()` to respect both new options and populate `headerNode` with dynamic context
- **`core-modular/test/services/navigation.service.spec.ts`** — Added 11 unit tests covering all `getTabNavData` scenarios (basic, parent fallback, config options, context propagation)
- **`core-modular/dev-tools/templates/simple/`** — Added UI example for `renderTabNav` with `headerNode` support using `luigi-container`, plus CSS for `.lui-tab-header`

## Configuration Example

```js
{
  pathSegment: 'alerts',
  label: 'Alerts',
  viewUrl: '/alerts-header.js',
  webcomponent: true,
  tabNav: {
    showAsTabHeader: true,
    hideTabNavAutomatically: true
  },
  children: [...]
}
```

## Test Plan

- [x] Unit tests pass (`npm test` — 118 tests, all green)
- [ ] Manual: navigate to a node with `hideTabNavAutomatically: true` and ≤1 child → tab bar hidden
- [ ] Manual: navigate to a node with `showAsTabHeader: true` → header WC renders above tabs, receives context updates on tab switch
- [ ] Manual: navigate to a node with `tabNav: true` (boolean) → existing behavior unchanged

Closes #5422
