### PR TITLE
fix preventContextUpdate in core-modular

### DIFF
--- a/core-modular/dev-tools/templates/simple/luigi-config.js
+++ b/core-modular/dev-tools/templates/simple/luigi-config.js
@@ -414,6 +414,24 @@ window.onload = () => {
           ]
         },
         {
+          pathSegment: 'withoptionstest',
+          label: 'WithOptions Test',
+          icon: 'lab',
+          viewUrl: '/microfrontend.html',
+          children: [
+            {
+              pathSegment: 'child1',
+              label: 'Child 1',
+              viewUrl: '/microfrontend.html'
+            },
+            {
+              pathSegment: 'child2',
+              label: 'Child 2',
+              viewUrl: '/withoptions-test.html'
+            }
+          ]
+        },
+        {
           pathSegment: 'parent',
           label: 'parent',
           viewUrl: '/microfrontend.html#parent',

--- a/core-modular/dev-tools/templates/simple/withoptions-test.html
+++ b/core-modular/dev-tools/templates/simple/withoptions-test.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>WithOptions Test</title>
+    <meta charset="utf-8" />
+    <script src="./public_client/luigi-client.js"></script>
+    <style>
+      body {
+        font-family: var(--sapFontFamily);
+        text-align: center;
+        color: #515559;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>WithOptions Test Page</h1>
+      <p>This content should REMAIN visible after preventContextUpdate navigation.</p>
+      <p>If you see "Luigi Simple Development Template" instead, the bug is present.</p>
+      <ul>
+        <li>
+          <a
+            href="#"
+            onclick="LuigiClient.linkManager().withOptions({ preventContextUpdate: true }).navigate('/withoptionstest'); return false;"
+          >
+            Navigate to /withoptionstest with preventContextUpdate (iframe should stay)
+          </a>
+        </li>
+        <li>
+          <a
+            href="#"
+            onclick="LuigiClient.linkManager().navigate('/withoptionstest'); return false;"
+          >
+            Navigate to /withoptionstest WITHOUT preventContextUpdate (iframe should change)
+          </a>
+        </li>
+      </ul>
+    </div>
+    <script>
+      LuigiClient.addInitListener(() => {
+        console.log('WithOptions Test MFE initialized');
+      });
+      LuigiClient.addContextUpdateListener((ctx) => {
+        console.log('WithOptions Test MFE context updated', ctx);
+      });
+    </script>
+  </body>
+</html>

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -349,13 +349,15 @@ export const UIModule = {
           ) {
             viewGroupContainer = element;
           } else if (
-            preventContextUpdate ||
-            (!currentNode.viewGroup &&
+            // preventContextUpdate bypasses only the URL match, not the type exclusions.
+            // The type guards must remain: in multi-container scenarios (viewGroups, preloading)
+            // skipping them would match every element and select the last in DOM order.
+            !currentNode.viewGroup &&
               !currentNode.isolateView &&
               !currentNode.webcomponent &&
               element.viewurl &&
-              resolvedViewUrl &&
-              GenericHelpers.isSameUrl(element.viewurl, resolvedViewUrl))
+              (preventContextUpdate ||
+                (resolvedViewUrl && GenericHelpers.isSameUrl(element.viewurl, resolvedViewUrl)))
           ) {
             viewGroupContainer = element;
           } else {

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -349,12 +349,13 @@ export const UIModule = {
           ) {
             viewGroupContainer = element;
           } else if (
-            !currentNode.viewGroup &&
-            !currentNode.isolateView &&
-            !currentNode.webcomponent &&
-            element.viewurl &&
-            resolvedViewUrl &&
-            GenericHelpers.isSameUrl(element.viewurl, resolvedViewUrl)
+            preventContextUpdate ||
+            (!currentNode.viewGroup &&
+              !currentNode.isolateView &&
+              !currentNode.webcomponent &&
+              element.viewurl &&
+              resolvedViewUrl &&
+              GenericHelpers.isSameUrl(element.viewurl, resolvedViewUrl))
           ) {
             viewGroupContainer = element;
           } else {
@@ -373,7 +374,7 @@ export const UIModule = {
       if (viewGroupContainer) {
         const previousViewUrl = viewGroupContainer.viewurl;
 
-        if (!withoutSync) {
+        if (!withoutSync && !preventContextUpdate) {
           viewGroupContainer.style.display = 'block';
           viewGroupContainer.viewurl = resolvedViewUrl;
           viewGroupContainer.nodeParams = nodeParams;

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -349,9 +349,6 @@ export const UIModule = {
           ) {
             viewGroupContainer = element;
           } else if (
-            // preventContextUpdate bypasses only the URL match, not the type exclusions.
-            // The type guards must remain: in multi-container scenarios (viewGroups, preloading)
-            // skipping them would match every element and select the last in DOM order.
             !currentNode.viewGroup &&
               !currentNode.isolateView &&
               !currentNode.webcomponent &&

--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -1172,7 +1172,7 @@ export class NavigationService {
 
       if (hashRouting) {
         const hashPath = GenericHelpers.addLeadingSlash(normalizedPath);
-        if (!withoutSync && method !== 'replaceState') {
+        if (!withoutSync && !preventContextUpdate && method !== 'replaceState') {
           location.hash = hashPath;
         } else {
           const event = new CustomEvent<NavigationRequestBase>('hashchange', eventDetail);
@@ -1416,7 +1416,7 @@ export class NavigationService {
    * @param options.fromContext - If set, returns the path relative to the ancestor whose `navigationContext` matches this value.
    * @returns The current route path relative to the resolved context node, or the full sub-path if no option is set.
    */
-  async getCurrentRoutePath(options: NavigationOptions): Promise<string|undefined> {
+  async getCurrentRoutePath(options: NavigationOptions): Promise<string | undefined> {
     const { fromVirtualTreeRoot, fromContext, fromClosestContext, fromParent } = options;
     const hashRouting = this.luigi.getConfigValue('routing.useHashRouting');
     const { path: currentPath, query } = RoutingHelpers.getCurrentPath(this.luigi, hashRouting);

--- a/core-modular/test/modules/ui-module-prevent-context-update.spec.ts
+++ b/core-modular/test/modules/ui-module-prevent-context-update.spec.ts
@@ -1,0 +1,156 @@
+jest.mock('@luigi-project/container', () => ({
+  __esModule: true,
+  default: {},
+  LuigiContainer: class {},
+  LuigiCompoundContainer: class {}
+}));
+
+jest.mock('../../src/services/service-registry', () => ({
+  serviceRegistry: { get: jest.fn() }
+}));
+
+jest.mock('../../src/services/navigation.service', () => ({ NavigationService: class {} }));
+jest.mock('../../src/services/preloading.service', () => ({ PreloadingService: class {} }));
+jest.mock('../../src/services/routing.service', () => ({ RoutingService: class {} }));
+jest.mock('../../src/services/dirty-status.service', () => ({ DirtyStatusService: class {} }));
+jest.mock('../../src/services/viewurl-decorator', () => ({ ViewUrlDecoratorSvc: class {} }));
+jest.mock('../../src/services/modal.service', () => ({ ModalService: class {} }));
+jest.mock('../../src/services/node-data-management.service', () => ({ NodeDataManagementService: class {} }));
+jest.mock('../../src/utilities/helpers/routing-helpers', () => ({
+  RoutingHelpers: {
+    substituteViewUrl: jest.fn().mockImplementation((node: any) => node.viewUrl),
+    checkWCUrl: jest.fn().mockReturnValue(true)
+  }
+}));
+jest.mock('../../src/utilities/helpers/navigation-helpers', () => ({
+  NavigationHelpers: { findVirtualTreeRootNode: jest.fn() }
+}));
+jest.mock('../../src/utilities/helpers/generic-helpers', () => ({
+  GenericHelpers: {
+    getRandomId: jest.fn().mockReturnValue('random-id'),
+    isFunction: jest.fn((fn: any) => typeof fn === 'function'),
+    isSameUrl: jest.fn((a: string, b: string) => a === b)
+  }
+}));
+jest.mock('../../src/utilities/helpers/auth-helpers', () => ({
+  AuthHelpers: { getStoredAuthData: jest.fn() }
+}));
+
+import { UIModule } from '../../src/modules/ui-module';
+import { serviceRegistry } from '../../src/services/service-registry';
+import { ViewUrlDecoratorSvc } from '../../src/services/viewurl-decorator';
+import { ModalService } from '../../src/services/modal.service';
+import { DirtyStatusService } from '../../src/services/dirty-status.service';
+
+describe('UIModule.updateMainContent - preventContextUpdate', () => {
+  let mockLuigi: any;
+  let mockConnector: any;
+  let containerWrapper: HTMLElement;
+
+  beforeEach(() => {
+    containerWrapper = document.createElement('div');
+    mockConnector = {
+      getContainerWrapper: jest.fn().mockReturnValue(containerWrapper),
+      showLoadingIndicator: jest.fn(),
+      hideLoadingIndicator: jest.fn()
+    };
+    mockLuigi = {
+      getConfigValue: jest.fn().mockReturnValue(undefined),
+      readUserSettings: jest.fn().mockResolvedValue({}),
+      featureToggles: () => ({ getActiveFeatureToggleList: () => [] }),
+      i18n: () => ({ getCurrentLocale: () => 'en' }),
+      theming: () => ({ getCurrentTheme: () => 'sap_horizon', getCSSVariables: () => Promise.resolve({}) }),
+      getEngine: () => ({
+        _connector: mockConnector,
+        _comm: { addListeners: jest.fn() }
+      })
+    };
+
+    const mockViewUrlDecoratorSvc = { applyDecorators: jest.fn().mockImplementation((url: string) => url) };
+    const mockModalService = { registerModal: jest.fn(), getModalSettings: jest.fn().mockReturnValue({}) };
+    const mockDirtyStatusService = { shouldShowUnsavedChangesModal: jest.fn().mockReturnValue(false) };
+
+    (serviceRegistry.get as jest.Mock).mockImplementation((service: any) => {
+      if (service === ViewUrlDecoratorSvc) return mockViewUrlDecoratorSvc;
+      if (service === ModalService) return mockModalService;
+      if (service === DirtyStatusService) return mockDirtyStatusService;
+      return {};
+    });
+
+    UIModule.modalContainer = [];
+    UIModule.drawerContainer = undefined;
+  });
+
+  function createMockContainer(viewurl: string): any {
+    const el = document.createElement('luigi-container') as any;
+    el.viewurl = viewurl;
+    el.updateContext = jest.fn();
+    el.updateViewUrl = jest.fn();
+    return el;
+  }
+
+  it('should preserve existing container when preventContextUpdate is true and viewUrls differ', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html' } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, true);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(true);
+    expect(containerWrapper.children.length).toBe(1);
+    expect(existingContainer.viewurl).toBe('/withoptions.html');
+  });
+
+  it('should not update viewurl or properties when preventContextUpdate is true', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    existingContainer.nodeParams = { original: 'params' };
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html', clientPermissions: { urlPatterns: true } } as any;
+    const luigiParams = { nodeParams: { new: 'params' }, pathParams: {}, searchParams: {} };
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, luigiParams, false, true);
+
+    expect(existingContainer.viewurl).toBe('/withoptions.html');
+    expect(existingContainer.nodeParams).toEqual({ original: 'params' });
+  });
+
+  it('should not trigger context update when preventContextUpdate is true', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html', context: { some: 'data' } } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, true);
+
+    expect(existingContainer.updateContext).not.toHaveBeenCalled();
+    expect(existingContainer.updateViewUrl).not.toHaveBeenCalled();
+  });
+
+  it('should remove container and create new one when preventContextUpdate is false and viewUrls differ', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html' } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, false);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(false);
+    expect(containerWrapper.children.length).toBe(1);
+    const newContainer = containerWrapper.children[0] as any;
+    expect(newContainer.viewurl).toBe('/multipurpose.html');
+  });
+
+  it('should reuse container and update context when preventContextUpdate is false and viewUrls match', async () => {
+    const existingContainer = createMockContainer('/multipurpose.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html', context: { updated: true } } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, false);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(true);
+    expect(existingContainer.updateContext).toHaveBeenCalledWith({ updated: true }, { withoutSync: false });
+  });
+});

--- a/core-modular/test/modules/ui-module-prevent-context-update.spec.ts
+++ b/core-modular/test/modules/ui-module-prevent-context-update.spec.ts
@@ -153,4 +153,37 @@ describe('UIModule.updateMainContent - preventContextUpdate', () => {
     expect(containerWrapper.contains(existingContainer)).toBe(true);
     expect(existingContainer.updateContext).toHaveBeenCalledWith({ updated: true }, { withoutSync: false });
   });
+
+  it('should not match container when node is webcomponent even with preventContextUpdate', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html', webcomponent: true } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, true);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(false);
+  });
+
+  it('should not match container when node has isolateView even with preventContextUpdate', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html', isolateView: true } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, true);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(false);
+  });
+
+  it('should not match container when node has viewGroup even with preventContextUpdate', async () => {
+    const existingContainer = createMockContainer('/withoptions.html');
+    containerWrapper.appendChild(existingContainer);
+
+    const targetNode = { viewUrl: '/multipurpose.html', viewGroup: 'myGroup' } as any;
+
+    await UIModule.updateMainContent(targetNode, mockLuigi, {}, false, true);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(false);
+  });
 });

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -938,6 +938,40 @@ describe('NavigationService', () => {
       window.location.hash = originalHash;
     });
 
+    it('should dispatch CustomEvent with preventContextUpdate detail instead of setting location.hash directly', async () => {
+      luigiMock.getConfig.mockReturnValue({ routing: { useHashRouting: true } });
+
+      const pushStateSpy = jest.spyOn(window.history, 'pushState').mockImplementation(() => {});
+      const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+      const navRequestParams: NavigationRequestParams = {
+        modalSettings: undefined,
+        newTab: false,
+        path: '/projects',
+        preserveView: undefined,
+        preventContextUpdate: true,
+        preventHistoryEntry: false,
+        withoutSync: false
+      };
+
+      await navigationService.handleNavigationRequest(navRequestParams);
+
+      expect(mockModalService.closeModalsWithDirtyCheck).toHaveBeenCalled();
+      expect(pushStateSpy).toHaveBeenCalledWith({ path: '/#/projects' }, '', '/#/projects');
+      expect(dispatchEventSpy).toHaveBeenCalledWith(expect.any(CustomEvent));
+
+      const dispatchedEvent = dispatchEventSpy.mock.calls[0][0] as CustomEvent;
+
+      expect(dispatchedEvent.type).toEqual('hashchange');
+      expect(dispatchedEvent.detail).toEqual({
+        preventContextUpdate: true,
+        preventHistoryEntry: false,
+        withoutSync: false
+      });
+
+      pushStateSpy.mockRestore();
+      dispatchEventSpy.mockRestore();
+    });
+
     it('should navigate to a path in new browser tab', async () => {
       const openViewInNewTabSpy = jest.spyOn(navigationService, 'openViewInNewTab');
       jest.spyOn(navigationService, 'buildPath').mockResolvedValue('/test/path');


### PR DESCRIPTION
## Fix: preventContextUpdate does not preserve iframe when navigating to different viewUrl

Fixes #5424

### Problem

`LuigiClient.linkManager().withOptions({ preventContextUpdate: true }).navigate('/path')` replaces the iframe/container content when navigating to a node with a different `viewUrl`. The expected behavior (matching core) is to only update the URL and navigation UI while leaving the iframe untouched.

### Root Cause

Two issues:

1. **`navigation.service.ts`** — The `preventContextUpdate` flag is lost during hash routing. When `withoutSync` is false, the code uses `location.hash = hashPath` which triggers a native `hashchange` event without `event.detail`. The flag never reaches `handleRouteChange`.

2. **`ui-module.ts`** — Even if the flag arrives, the existing container is removed because `isSameUrl(oldViewUrl, newViewUrl)` fails for different viewUrls. The `preventContextUpdate` check only happens later — after the container is already gone.

### Fix

**`navigation.service.ts`:**
```diff
- if (!withoutSync && method !== 'replaceState') {
+ if (!withoutSync && !preventContextUpdate && method !== 'replaceState') {
    location.hash = hashPath;
```
Forces the `CustomEvent` path (which carries `detail.preventContextUpdate`) — matching how core always uses `history.pushState` + `CustomEvent('popstate')`.

**`ui-module.ts` (container loop):**
```diff
  } else if (
+   preventContextUpdate ||
-   !currentNode.viewGroup &&
+   (!currentNode.viewGroup &&
    ...
-   GenericHelpers.isSameUrl(element.viewurl, resolvedViewUrl)
+   GenericHelpers.isSameUrl(element.viewurl, resolvedViewUrl))
  ) {
    viewGroupContainer = element;
```
Preserves the existing container when `preventContextUpdate` is set.

**`ui-module.ts` (property update block):**
```diff
- if (!withoutSync) {
+ if (!withoutSync && !preventContextUpdate) {
    viewGroupContainer.viewurl = resolvedViewUrl;
```
Prevents overwriting the container's viewUrl/properties, so the iframe content stays intact.

### Behavior Alignment with Core

In **core** (`core/src/services/routing.js`):
- Navigation always uses `history.pushState` + `CustomEvent('popstate')` — never `location.hash =`
- When `preventContextUpdate` is true, `Iframe.navigateIframe()` is simply skipped (line 490)
- The navigation UI (side nav, breadcrumbs) still updates normally

This fix replicates that behavior in core-modular.

### Test Plan

- [ ] Navigate to a child node with a unique viewUrl (e.g. `/projects/pr2` → `withoptions.html`)
- [ ] From the MFE, call `linkManager().withOptions({ preventContextUpdate: true }).navigate('/projects')`
- [ ] Verify: URL changes to `/projects`, side nav updates, but iframe still shows `withoptions.html`
- [ ] Verify: Normal navigation (without `preventContextUpdate`) still works as before
- [ ] Verify: `withoutSync` behavior is unaffected
- [ ] Verify: `preventHistoryEntry` behavior is unaffected
