### PR TITLE
fix withoutSync in core-modular

### DIFF
--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -344,6 +344,7 @@ export const UIModule = {
           }
         } else {
           if (
+            withoutSync ||
             element.viewGroup ||
             (element.virtualTree && currentVirtualTreeRootNode === element.virtualTreeRootNode)
           ) {
@@ -395,11 +396,11 @@ export const UIModule = {
           const hashChanged =
             GenericHelpers.isSameUrl(previousViewUrl, resolvedViewUrl) && previousViewUrl !== resolvedViewUrl;
 
-          if (hashChanged && !viewGroupContainer.virtualTree) {
+          if (hashChanged && !viewGroupContainer.virtualTree && !withoutSync) {
             viewGroupContainer.context = currentNode.context || {};
             viewGroupContainer.updateViewUrl(resolvedViewUrl);
           } else {
-            viewGroupContainer.updateContext(currentNode.context || {}, { withoutSync: false });
+            viewGroupContainer.updateContext(currentNode.context || {}, { withoutSync: !!withoutSync });
           }
         }
       } else {

--- a/core-modular/src/modules/ui-module.ts
+++ b/core-modular/src/modules/ui-module.ts
@@ -391,6 +391,15 @@ export const UIModule = {
           setAllowRules(viewGroupContainer, luigi);
         }
 
+        if (withoutSync && !preventContextUpdate) {
+          // withoutSync: forward the fresh params to the client so navigations that change
+          // node/path/search params don't leave the client with stale params (parity with core).
+          // Deliberately does NOT touch viewurl/display, preserving the no-reload guarantee.
+          viewGroupContainer.nodeParams = nodeParams;
+          viewGroupContainer.pathParams = pathParams;
+          viewGroupContainer.searchParams = searchParams;
+        }
+
         if (!preventContextUpdate) {
           //IMPORTANT!!! This needs to be at the end
           const hashChanged =

--- a/core-modular/test/modules/ui-module-without-sync.spec.ts
+++ b/core-modular/test/modules/ui-module-without-sync.spec.ts
@@ -106,6 +106,58 @@ describe('UIModule.updateMainContent - withoutSync', () => {
     expect(existingContainer.updateViewUrl).not.toHaveBeenCalled();
   });
 
+  it('should forward fresh params to the container when withoutSync is true', async () => {
+    existingContainer.nodeParams = { old: 'node' };
+    existingContainer.pathParams = { old: 'path' };
+    existingContainer.searchParams = { old: 'search' };
+
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html',
+      context: { project: 'new-project' }
+    };
+    const luigiParams = {
+      nodeParams: { fresh: 'node' },
+      pathParams: { fresh: 'path' },
+      searchParams: { fresh: 'search' }
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, luigiParams as any, true, false);
+
+    // fresh params are forwarded so the client does not receive stale params (parity with core)
+    expect(existingContainer.nodeParams).toEqual({ fresh: 'node' });
+    expect(existingContainer.pathParams).toEqual({ fresh: 'path' });
+    expect(existingContainer.searchParams).toEqual({ fresh: 'search' });
+    // viewurl untouched -> no iframe reload
+    expect(existingContainer.viewurl).toBe('https://example.com/current-mfe.html');
+    expect(existingContainer.updateContext).toHaveBeenCalledWith(
+      { project: 'new-project' },
+      { withoutSync: true }
+    );
+  });
+
+  it('should not update params when withoutSync and preventContextUpdate are both true', async () => {
+    existingContainer.nodeParams = { old: 'node' };
+    existingContainer.pathParams = { old: 'path' };
+    existingContainer.searchParams = { old: 'search' };
+
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html'
+    };
+    const luigiParams = {
+      nodeParams: { fresh: 'node' },
+      pathParams: { fresh: 'path' },
+      searchParams: { fresh: 'search' }
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, luigiParams as any, true, true);
+
+    expect(existingContainer.nodeParams).toEqual({ old: 'node' });
+    expect(existingContainer.pathParams).toEqual({ old: 'path' });
+    expect(existingContainer.searchParams).toEqual({ old: 'search' });
+  });
+
   it('should not call updateContext when both withoutSync and preventContextUpdate are true', async () => {
     const currentNode = {
       label: 'Target',

--- a/core-modular/test/modules/ui-module-without-sync.spec.ts
+++ b/core-modular/test/modules/ui-module-without-sync.spec.ts
@@ -1,0 +1,137 @@
+jest.mock('@luigi-project/container', () => ({
+  __esModule: true,
+  default: {},
+  LuigiContainer: class {},
+  LuigiCompoundContainer: class {}
+}));
+
+jest.mock('../../src/services/service-registry', () => ({
+  serviceRegistry: { get: jest.fn() }
+}));
+
+jest.mock('../../src/services/navigation.service', () => ({ NavigationService: class {} }));
+jest.mock('../../src/services/preloading.service', () => ({ PreloadingService: class {} }));
+jest.mock('../../src/services/routing.service', () => ({ RoutingService: class {} }));
+jest.mock('../../src/services/dirty-status.service', () => ({ DirtyStatusService: class {} }));
+jest.mock('../../src/services/modal.service', () => ({ ModalService: class {} }));
+jest.mock('../../src/utilities/helpers/auth-helpers', () => ({
+  AuthHelpers: { getStoredAuthData: jest.fn().mockReturnValue(null) }
+}));
+
+import { UIModule } from '../../src/modules/ui-module';
+import { serviceRegistry } from '../../src/services/service-registry';
+
+describe('UIModule.updateMainContent - withoutSync', () => {
+  let containerWrapper: HTMLDivElement;
+  let mockLuigi: any;
+  let existingContainer: any;
+
+  beforeEach(() => {
+    containerWrapper = document.createElement('div');
+
+    existingContainer = document.createElement('luigi-container');
+    existingContainer.viewurl = 'https://example.com/current-mfe.html';
+    existingContainer.style.display = 'block';
+    existingContainer.updateContext = jest.fn();
+    existingContainer.updateViewUrl = jest.fn();
+    containerWrapper.appendChild(existingContainer);
+
+    mockLuigi = {
+      getEngine: () => ({
+        _connector: {
+          getContainerWrapper: () => containerWrapper,
+          hideLoadingIndicator: jest.fn(),
+          showLoadingIndicator: jest.fn()
+        }
+      }),
+      getConfigValue: jest.fn().mockReturnValue(undefined),
+      readUserSettings: jest.fn().mockResolvedValue({}),
+      i18n: () => ({ getCurrentLocale: () => 'en' }),
+      theming: () => ({ getCurrentTheme: () => 'sap_horizon', getCSSVariables: jest.fn().mockResolvedValue({}) }),
+      featureToggles: () => ({ getActiveFeatureToggleList: () => [] })
+    };
+
+    (serviceRegistry.get as jest.Mock).mockImplementation(() => ({
+      applyDecorators: (url: string) => url
+    }));
+  });
+
+  it('should preserve existing container when withoutSync is true and viewUrls differ', async () => {
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html'
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, undefined, true, false);
+
+    expect(containerWrapper.contains(existingContainer)).toBe(true);
+    expect(existingContainer.style.display).toBe('block');
+  });
+
+  it('should not update viewurl property when withoutSync is true', async () => {
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html'
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, undefined, true, false);
+
+    expect(existingContainer.viewurl).toBe('https://example.com/current-mfe.html');
+  });
+
+  it('should call updateContext with withoutSync: true when withoutSync is true', async () => {
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html',
+      context: { project: 'new-project' }
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, undefined, true, false);
+
+    expect(existingContainer.updateContext).toHaveBeenCalledWith(
+      { project: 'new-project' },
+      { withoutSync: true }
+    );
+  });
+
+  it('should not call updateViewUrl when withoutSync is true even if hash changed', async () => {
+    existingContainer.viewurl = 'https://example.com/mfe.html#page1';
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/mfe.html#page2'
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, undefined, true, false);
+
+    expect(existingContainer.updateViewUrl).not.toHaveBeenCalled();
+  });
+
+  it('should not call updateContext when both withoutSync and preventContextUpdate are true', async () => {
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html',
+      context: { project: 'new-project' }
+    };
+
+    await UIModule.updateMainContent(currentNode as any, mockLuigi, undefined, true, true);
+
+    expect(existingContainer.updateContext).not.toHaveBeenCalled();
+  });
+
+  it('should remove container from DOM when withoutSync is false and viewUrls differ', async () => {
+    const removeSpy = jest.spyOn(existingContainer, 'remove');
+    const currentNode = {
+      label: 'Target',
+      viewUrl: 'https://example.com/different-mfe.html'
+    };
+
+    // createContainer will throw due to missing mocks, but we only care that remove() was called
+    try {
+      await UIModule.updateMainContent(currentNode as any, mockLuigi, undefined, false, false);
+    } catch (e) {
+      // expected — createContainer needs more mocks
+    }
+
+    expect(removeSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fix `withoutSync()` navigation in core-modular which incorrectly replaced the existing container instead of preserving it.

Closes #5428

## Problem

When navigating with `LuigiClient.linkManager().withoutSync().navigate(path)` to a node with a different `viewUrl`, the existing `luigi-container` was destroyed and replaced. The expected behavior (matching core) is that only the URL and navigation highlight update while the MFE content stays untouched.

### Root Cause (ui-module.ts → `updateMainContent`)

1. The container loop only recognized a container as reusable if `viewGroup`/`virtualTree` matched or the `viewUrl` was identical — with a different `viewUrl` and `withoutSync`, the container fell through to the removal branch
2. `updateContext` was always called with `{ withoutSync: false }` regardless of the actual navigation flag
3. `updateViewUrl` was triggered on hash-only URL changes even during `withoutSync` navigation

## Changes

### `core-modular/src/modules/ui-module.ts`

- **Container preservation**: Added `withoutSync` as a condition to treat the existing container as `viewGroupContainer`, preventing its removal
- **Correct flag propagation**: Pass `{ withoutSync: !!withoutSync }` to `updateContext` instead of hardcoded `false`
- **Skip `updateViewUrl`**: When `withoutSync` is true, do not call `updateViewUrl` even if the hash portion of the URL changed

### `core-modular/test/modules/ui-module-without-sync.spec.ts` (new)

6 unit tests covering:
- Container preserved when `withoutSync=true` and viewUrls differ
- `viewurl` property not overwritten
- `updateContext` called with `{ withoutSync: true }`
- `updateViewUrl` not called on hash change
- No `updateContext` when both `withoutSync` and `preventContextUpdate` are true
- Container removed when `withoutSync=false` (existing behavior unchanged)

## Test Plan

- [x] All existing unit tests pass (`npx jest test/modules/ test/services/navigation.service.spec.ts`)
- [ ] Manual test: Navigate with `withoutSync()` to a node with different viewUrl → iframe stays, URL + nav highlight update
- [ ] Manual test: Normal navigation (without `withoutSync`) still replaces container as expected
