### PR TITLE
fix(container): guard against null mainComponent in deferred createIf…

### DIFF
--- a/container/cypress/e2e/test-app/iframe/iframe-container-race.cy.js
+++ b/container/cypress/e2e/test-app/iframe/iframe-container-race.cy.js
@@ -1,0 +1,48 @@
+// Regression test for luigi-project/luigi#5403
+//
+// createIframe() is scheduled via setTimeout at the end of initialize().
+// If the <luigi-container> is removed from the DOM before that deferred
+// callback fires (e.g. a navigation re-sync in path routing mode), Svelte
+// resets the `bind:this` reference (`mainComponent`) to null, which used to
+// crash with "TypeError: Cannot read properties of null (reading 'appendChild')".
+//
+// The container now guards against a null `mainComponent` and bails out.
+describe('Iframe Container removed before deferred iframe creation (#5403)', () => {
+  it('does not throw when the container is removed before createIframe runs', () => {
+    let raceError = null;
+
+    cy.on('uncaught:exception', (err) => {
+      if (err.message.includes('Cannot read properties of null') && err.message.includes('appendChild')) {
+        // Capture the regression error and assert on it below instead of
+        // letting Cypress fail immediately, so the assertion message is clear.
+        raceError = err;
+        return false;
+      }
+      // Let unrelated exceptions fail the test as usual.
+      return undefined;
+    });
+
+    cy.visit('http://localhost:8080/iframe/iframeContainerRace.html');
+
+    cy.get('#content').then(($content) => {
+      cy.window().then((win) => {
+        const container = win.document.createElement('luigi-container');
+        container.viewurl = './microfrontend.html';
+        $content[0].appendChild(container);
+
+        // Remove the container before the deferred createIframe() setTimeout
+        // fires. A microtask always runs before the next macrotask (the
+        // setTimeout), so Svelte nulls `mainComponent` first and the guard is
+        // exercised on the exact code path reported in the issue.
+        win.queueMicrotask(() => container.remove());
+      });
+    });
+
+    // Give the deferred setTimeout enough time to fire.
+    cy.wait(300);
+
+    cy.then(() => {
+      expect(raceError, 'null appendChild TypeError should not be thrown').to.equal(null);
+    });
+  });
+});

--- a/container/src/LuigiContainer.svelte
+++ b/container/src/LuigiContainer.svelte
@@ -322,10 +322,6 @@
   onDestroy(async () => {});
 
   function createIframe(): void {
-    // createIframe is deferred via setTimeout in initialize(). If the container
-    // was removed from the DOM in the meantime (e.g. a navigation re-sync in
-    // path routing mode), Svelte resets the `bind:this` reference to null.
-    // Bail out instead of throwing "Cannot read properties of null (reading 'appendChild')".
     if (!mainComponent) {
       return;
     }

--- a/container/src/LuigiContainer.svelte
+++ b/container/src/LuigiContainer.svelte
@@ -322,6 +322,13 @@
   onDestroy(async () => {});
 
   function createIframe(): void {
+    // createIframe is deferred via setTimeout in initialize(). If the container
+    // was removed from the DOM in the meantime (e.g. a navigation re-sync in
+    // path routing mode), Svelte resets the `bind:this` reference to null.
+    // Bail out instead of throwing "Cannot read properties of null (reading 'appendChild')".
+    if (!mainComponent) {
+      return;
+    }
     const iframe = document.createElement('iframe');
     iframe.title = label || '';
     iframe.src = viewurl;

--- a/container/test-app/iframe/iframeContainerRace.html
+++ b/container/test-app/iframe/iframeContainerRace.html
@@ -6,8 +6,8 @@
   </head>
   <body>
     <h3>
-      Regression fixture for luigi-project/luigi#5403 – a luigi-container is
-      created and removed before its deferred iframe creation runs.
+      Regression fixture for luigi-project/luigi#5403 – a luigi-container is created and
+      removed before its deferred iframe creation runs.
     </h3>
     <div id="content" style="border: solid 1px blue; height: 400px"></div>
   </body>

--- a/container/test-app/iframe/iframeContainerRace.html
+++ b/container/test-app/iframe/iframeContainerRace.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <script type="module">
+      import '../bundle.js';
+    </script>
+  </head>
+  <body>
+    <h3>
+      Regression fixture for luigi-project/luigi#5403 – a luigi-container is
+      created and removed before its deferred iframe creation runs.
+    </h3>
+    <div id="content" style="border: solid 1px blue; height: 400px"></div>
+  </body>
+</html>


### PR DESCRIPTION
…rame

createIframe() is scheduled via setTimeout in initialize(). If the <luigi-container> is removed from the DOM before the callback fires (e.g. a navigation re-sync in path routing mode), Svelte resets the bind:this reference to null, causing
'TypeError: Cannot read properties of null (reading appendChild)'.

Bail out early when mainComponent is null.

Fixes luigi-project/luigi#5403

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow the contributing guidelines: https://github.com/luigi-project/luigi/blob/main/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update any relevant documentation.
4. Sign the Contributor License Agreement.
-->

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
