### PR TITLE
fix(core-modular): open a modal whose path equals the current location

### DIFF
--- a/core-modular/src/services/navigation.service.ts
+++ b/core-modular/src/services/navigation.service.ts
@@ -1135,7 +1135,15 @@ export class NavigationService {
     const { path: currentPath, query: currentQuery } = RoutingHelpers.getCurrentPath(this.luigi, hashRouting);
     const currentFullPath = currentPath + (currentQuery ? '?' + currentQuery : '');
 
-    if (GenericHelpers.trimLeadingSlash(currentFullPath) === GenericHelpers.trimLeadingSlash(normalizedPath)) {
+    // Navigating to the page you are already on is a no-op, but an overlay is not a navigation:
+    // a modal or drawer is independent of the main route, so it must open even when its path
+    // equals the current location.
+    const isOverlayRequest = Boolean(drawerSettings || modalSettings);
+
+    if (
+      !isOverlayRequest &&
+      GenericHelpers.trimLeadingSlash(currentFullPath) === GenericHelpers.trimLeadingSlash(normalizedPath)
+    ) {
       return;
     }
 

--- a/core-modular/test/services/navigation.service.spec.ts
+++ b/core-modular/test/services/navigation.service.spec.ts
@@ -904,6 +904,77 @@ describe('NavigationService', () => {
       expect(openAsModalMock).toHaveBeenCalledWith('/modal/path', { size: 'l' }, expect.any(Function));
     });
 
+    it('should call openAsModal even when the path equals the current location', async () => {
+      const openAsModalMock = jest.fn();
+      jest.spyOn(navigationService, 'buildPath').mockResolvedValue('/projects/pr2');
+      jest.spyOn(RoutingHelpers, 'getCurrentPath').mockReturnValue({ path: '/projects/pr2', query: '' });
+      const navRequestParams: NavigationRequestParams = {
+        modalSettings: { size: 'l', keepPrevious: true },
+        newTab: false,
+        path: '/projects/pr2',
+        preserveView: undefined,
+        preventContextUpdate: false,
+        preventHistoryEntry: false,
+        withoutSync: false
+      };
+
+      luigiMock.navigation = jest.fn().mockReturnValue({ openAsModal: openAsModalMock });
+
+      await navigationService.handleNavigationRequest(navRequestParams, jest.fn());
+
+      expect(openAsModalMock).toHaveBeenCalledWith(
+        '/projects/pr2',
+        { size: 'l', keepPrevious: true },
+        expect.any(Function)
+      );
+    });
+
+    it('should call openAsDrawer even when the path equals the current location', async () => {
+      const openAsDrawerMock = jest.fn();
+      jest.spyOn(navigationService, 'buildPath').mockResolvedValue('/projects/pr2');
+      jest.spyOn(RoutingHelpers, 'getCurrentPath').mockReturnValue({ path: '/projects/pr2', query: '' });
+      const navRequestParams: NavigationRequestParams = {
+        drawerSettings: { size: 's' },
+        newTab: false,
+        path: '/projects/pr2',
+        preserveView: undefined,
+        preventContextUpdate: false,
+        preventHistoryEntry: false,
+        withoutSync: false
+      };
+
+      luigiMock.navigation = jest.fn().mockReturnValue({ openAsDrawer: openAsDrawerMock });
+
+      await navigationService.handleNavigationRequest(navRequestParams, jest.fn());
+
+      expect(openAsDrawerMock).toHaveBeenCalledWith('/projects/pr2', { size: 's' }, expect.any(Function));
+    });
+
+    it('should still drop a plain navigation to the current location', async () => {
+      luigiMock.getConfig.mockReturnValue({ routing: { useHashRouting: false } });
+      jest.spyOn(navigationService, 'buildPath').mockResolvedValue('/projects/pr2');
+      jest.spyOn(RoutingHelpers, 'getCurrentPath').mockReturnValue({ path: '/projects/pr2', query: '' });
+      const pushStateSpy = jest.spyOn(window.history, 'pushState').mockImplementation(() => {});
+      const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+      const navRequestParams: NavigationRequestParams = {
+        modalSettings: undefined,
+        newTab: false,
+        path: '/projects/pr2',
+        preserveView: undefined,
+        preventContextUpdate: false,
+        preventHistoryEntry: false,
+        withoutSync: false
+      };
+
+      await navigationService.handleNavigationRequest(navRequestParams);
+
+      expect(pushStateSpy).not.toHaveBeenCalled();
+      expect(dispatchEventSpy).not.toHaveBeenCalled();
+
+      pushStateSpy.mockRestore();
+      dispatchEventSpy.mockRestore();
+    });
+
     it('should close modals and update history if no modalSettings and not using hash routing', async () => {
       luigiMock.getConfig.mockReturnValue({ routing: { useHashRouting: false } });
 


### PR DESCRIPTION
Closes #5437.

The same-path early return in `handleNavigationRequest` sits directly above the modal and drawer branch, so an overlay request whose path equals the current main location never reaches it. The guard is right for plain navigation and wrong for overlays, which are independent of the main route, so it now skips overlay requests and keeps applying to everything else.

```ts
const isOverlayRequest = Boolean(drawerSettings || modalSettings);

if (
  !isOverlayRequest &&
  GenericHelpers.trimLeadingSlash(currentFullPath) === GenericHelpers.trimLeadingSlash(normalizedPath)
) {
  return;
}
```

**Three tests, red first.** On `d3f884f` the two overlay cases fail and the control passes, which is what tells you the assertions are measuring this change rather than something that was already true:

| test | before | after |
| --- | --- | --- |
| `should call openAsModal even when the path equals the current location` | fails | passes |
| `should call openAsDrawer even when the path equals the current location` | fails | passes |
| `should still drop a plain navigation to the current location` | passes | passes |

Each one pins `RoutingHelpers.getCurrentPath` to the target path, which is the condition the issue describes, rather than relying on whatever the jsdom location happens to be. The drawer case is in because the guard sat above both branches, so both were affected, and the third one is there so a future refactor cannot quietly delete the no-op behaviour for ordinary navigation.

**What I ran**, on Windows with Node 22.20.0:

- `npx jest` in `core-modular`: 46 suites, 868 tests, all passing. Baseline on `d3f884f` was 46 suites and 865 tests, so the delta is exactly the three added here.
- `npx eslint ./src/services/navigation.service.ts`: 0 errors, 2 `prefer-const` warnings at lines 1251 and 1254, both in code this diff does not touch.
- `npx prettier --check` on both files reports them unformatted, but so does the same check on unmodified `main`, so that predates this change. The added lines follow the surrounding style.

**One thing you may want to follow up on.** The issue mentions that the migrated "multiple modals: keepPrevious=true" e2e test was worked around by starting the back-and-forth scenario at `/projects` instead of `/projects/pr2`, so no modal target equalled the base path. With this fix that workaround should no longer be needed. I left the e2e test alone rather than guess at your migration plan, but happy to revert the workaround in a follow-up if that is useful.
