### PR TITLE
Fix context switcher keyboard navigation and profile aria-expanded

### DIFF
--- a/core/src/navigation/ContextSwitcher.svelte
+++ b/core/src/navigation/ContextSwitcher.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher, onMount, getContext, beforeUpdate } from 'svelte';
+  import { createEventDispatcher, onMount, getContext, beforeUpdate, tick } from 'svelte';
   import { ContextSwitcherHelpers } from './services/context-switcher';
   import ContextSwitcherNav from './ContextSwitcherNav.svelte';
   import { LuigiConfig } from '../core-api';
@@ -213,14 +213,17 @@
     DropdownKeyboardHelpers.applyRovingTabindex(items, index);
   }
 
-  function closeAndFocusTrigger() {
+  async function closeAndFocusTrigger() {
     if (isDropdownOpen()) {
       toggleDropdownState();
     }
-    const trigger = document.querySelector('[data-testid="luigi-contextswitcher-button"]');
-    if (trigger) {
-      trigger.focus();
-    }
+    await tick();
+    setTimeout(() => {
+      const trigger = document.querySelector('[data-testid="luigi-contextswitcher-button"]');
+      if (trigger) {
+        trigger.focus();
+      }
+    }, 0);
   }
 
   function onTriggerMouseDown(event) {

--- a/core/src/navigation/ContextSwitcher.svelte
+++ b/core/src/navigation/ContextSwitcher.svelte
@@ -248,13 +248,14 @@
     DropdownKeyboardHelpers.handleTriggerKeydown(event, {
       isOpen: isDropdownOpen(),
       isDisabled: !renderAsDropdown || event.currentTarget.getAttribute('aria-disabled') === 'true',
+      isAnchor: event.currentTarget.tagName === 'A',
       onToggle: (focus) => {
         focusMenuOnOpen = focus || 'first';
-        if (DropdownKeyboardHelpers.isActivationKey(event)) {
+        if (event.currentTarget.tagName === 'A' && DropdownKeyboardHelpers.isActivationKey(event)) {
           skipNextTriggerClick = true;
           setTimeout(() => {
             skipNextTriggerClick = false;
-          }, 50);
+          }, 500);
         }
         toggleDropdownState();
       },
@@ -277,10 +278,11 @@
   <!-- DESKTOP VERSION (popover): -->
   {#if !isMobile}
     <div class="fd-shellbar__action fd-shellbar__action--desktop">
-      <div class="fd-popover fd-popover--right">
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <div class="fd-popover fd-popover--right" on:click|stopPropagation={() => {}}>
         <div class="fd-popover__control" role="presentation" on:click|stopPropagation={() => {}}>
-          {#if addNavHrefForAnchor && selectedOption !== config.defaultLabel}
+          {#if addNavHrefForAnchor && selectedOption}
             <a
               href={selectedOption ? getRouteLink(selectedOption) : undefined}
               class="fd-button fd-button--transparent fd-shellbar__button fd-button--menu fd-shellbar__button--menu lui-ctx-switch-menu"

--- a/core/src/navigation/ContextSwitcher.svelte
+++ b/core/src/navigation/ContextSwitcher.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher, onMount, getContext, beforeUpdate } from 'svelte';
+  import { createEventDispatcher, onMount, getContext, beforeUpdate, afterUpdate } from 'svelte';
   import { ContextSwitcherHelpers } from './services/context-switcher';
   import ContextSwitcherNav from './ContextSwitcherNav.svelte';
   import { LuigiConfig } from '../core-api';
@@ -10,7 +10,8 @@
     StateHelpers,
     NavigationHelpers,
     GenericHelpers,
-    EventListenerHelpers
+    EventListenerHelpers,
+    DropdownKeyboardHelpers
   } from '../utilities/helpers';
 
   const dispatch = createEventDispatcher();
@@ -40,6 +41,9 @@
   let selectedNodePath;
   export let addNavHrefForAnchor;
   let isContextSwitcherDropdownShown;
+  let popoverEl;
+  let wasDropdownShown = false;
+  let focusMenuOnOpen = 'first';
 
   onMount(async () => {
     StateHelpers.doOnStoreChange(store, async () => {
@@ -195,6 +199,68 @@
       fetchOptions();
     }
   }
+
+  function isDropdownOpen() {
+    return Boolean(dropDownStates && dropDownStates.contextSwitcherPopover);
+  }
+
+  function focusMenuItem(which) {
+    const items = DropdownKeyboardHelpers.getMenuItems(popoverEl);
+    if (!items.length) {
+      return;
+    }
+    const index = which === 'last' ? items.length - 1 : 0;
+    DropdownKeyboardHelpers.applyRovingTabindex(items, index);
+  }
+
+  function closeAndFocusTrigger() {
+    if (isDropdownOpen()) {
+      toggleDropdownState();
+    }
+    const trigger = document.querySelector('[data-testid="luigi-contextswitcher-button"]');
+    if (trigger) {
+      trigger.focus();
+    }
+  }
+
+  function onTriggerKeydown(event) {
+    DropdownKeyboardHelpers.handleTriggerKeydown(event, {
+      isOpen: isDropdownOpen(),
+      isDisabled: !renderAsDropdown || event.currentTarget.getAttribute('aria-disabled') === 'true',
+      isAnchor: event.currentTarget.tagName === 'A',
+      onToggle: (focus) => {
+        if (focus) {
+          focusMenuOnOpen = focus;
+        }
+        toggleDropdownState();
+      },
+      onFocusFirst: () => focusMenuItem('first'),
+      onFocusLast: () => focusMenuItem('last'),
+      onClose: closeAndFocusTrigger
+    });
+  }
+
+  function onPopoverKeydown(event) {
+    DropdownKeyboardHelpers.handleMenuKeydown(event, {
+      items: DropdownKeyboardHelpers.getMenuItems(event.currentTarget),
+      onEscape: closeAndFocusTrigger,
+      onActivate: (item) => item.click()
+    });
+  }
+
+  afterUpdate(() => {
+    if (!isContextSwitcherDropdownShown) {
+      wasDropdownShown = false;
+      return;
+    }
+    const items = DropdownKeyboardHelpers.getMenuItems(popoverEl);
+    if (!items.length || wasDropdownShown) {
+      return;
+    }
+    focusMenuItem(focusMenuOnOpen);
+    focusMenuOnOpen = 'first';
+    wasDropdownShown = true;
+  });
 </script>
 
 {#if contextSwitcherEnabled}
@@ -208,17 +274,15 @@
             <a
               href={selectedOption ? getRouteLink(selectedOption) : undefined}
               class="fd-button fd-button--transparent fd-shellbar__button fd-button--menu fd-shellbar__button--menu lui-ctx-switch-menu"
+              aria-controls="contextSwitcherPopover"
+              aria-expanded={dropDownStates.contextSwitcherPopover || false}
               aria-haspopup="true"
               tabindex="0"
               title={selectedLabel ? selectedLabel : config.defaultLabel}
               on:click|preventDefault={() => {
                 if (renderAsDropdown) toggleDropdownState();
               }}
-              on:keyup={(event) => {
-                if (renderAsDropdown) {
-                  (event.key === 'Enter' || event.code === 'Space') && toggleDropdownState();
-                }
-              }}
+              on:keydown={onTriggerKeydown}
               aria-disabled={!renderAsDropdown}
               data-testid="luigi-contextswitcher-button"
             >
@@ -240,11 +304,7 @@
               on:click={() => {
                 if (renderAsDropdown) toggleDropdownState();
               }}
-              on:keyup={(event) => {
-                if (renderAsDropdown) {
-                  (event.key === 'Enter' || event.code === 'Space') && toggleDropdownState();
-                }
-              }}
+              on:keydown={onTriggerKeydown}
               aria-disabled={!renderAsDropdown}
               data-testid="luigi-contextswitcher-button"
             >
@@ -257,11 +317,15 @@
             </button>
           {/if}
         </div>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
+          bind:this={popoverEl}
           class="fd-popover__body fd-popover__body--right"
           aria-hidden={!(dropDownStates.contextSwitcherPopover || false)}
           id="contextSwitcherPopover"
           data-testid="luigi-contextswitcher-popover"
+          on:keydown={onPopoverKeydown}
         >
           <ContextSwitcherNav
             {actions}

--- a/core/src/navigation/ContextSwitcher.svelte
+++ b/core/src/navigation/ContextSwitcher.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher, onMount, getContext, beforeUpdate, afterUpdate } from 'svelte';
+  import { createEventDispatcher, onMount, getContext, beforeUpdate } from 'svelte';
   import { ContextSwitcherHelpers } from './services/context-switcher';
   import ContextSwitcherNav from './ContextSwitcherNav.svelte';
   import { LuigiConfig } from '../core-api';
@@ -42,8 +42,8 @@
   export let addNavHrefForAnchor;
   let isContextSwitcherDropdownShown;
   let popoverEl;
-  let wasDropdownShown = false;
   let focusMenuOnOpen = 'first';
+  let skipNextTriggerClick = false;
 
   onMount(async () => {
     StateHelpers.doOnStoreChange(store, async () => {
@@ -223,14 +223,38 @@
     }
   }
 
+  function onTriggerMouseDown(event) {
+    if (renderAsDropdown) {
+      event.preventDefault();
+    }
+  }
+
+  function onTriggerClick(event) {
+    if (event) {
+      event.preventDefault();
+    }
+    if (!renderAsDropdown) {
+      return;
+    }
+    if (skipNextTriggerClick) {
+      skipNextTriggerClick = false;
+      return;
+    }
+    focusMenuOnOpen = 'first';
+    toggleDropdownState();
+  }
+
   function onTriggerKeydown(event) {
     DropdownKeyboardHelpers.handleTriggerKeydown(event, {
       isOpen: isDropdownOpen(),
       isDisabled: !renderAsDropdown || event.currentTarget.getAttribute('aria-disabled') === 'true',
-      isAnchor: event.currentTarget.tagName === 'A',
       onToggle: (focus) => {
-        if (focus) {
-          focusMenuOnOpen = focus;
+        focusMenuOnOpen = focus || 'first';
+        if (DropdownKeyboardHelpers.isActivationKey(event)) {
+          skipNextTriggerClick = true;
+          setTimeout(() => {
+            skipNextTriggerClick = false;
+          }, 50);
         }
         toggleDropdownState();
       },
@@ -247,20 +271,6 @@
       onActivate: (item) => item.click()
     });
   }
-
-  afterUpdate(() => {
-    if (!isContextSwitcherDropdownShown) {
-      wasDropdownShown = false;
-      return;
-    }
-    const items = DropdownKeyboardHelpers.getMenuItems(popoverEl);
-    if (!items.length || wasDropdownShown) {
-      return;
-    }
-    focusMenuItem(focusMenuOnOpen);
-    focusMenuOnOpen = 'first';
-    wasDropdownShown = true;
-  });
 </script>
 
 {#if contextSwitcherEnabled}
@@ -279,9 +289,8 @@
               aria-haspopup="true"
               tabindex="0"
               title={selectedLabel ? selectedLabel : config.defaultLabel}
-              on:click|preventDefault={() => {
-                if (renderAsDropdown) toggleDropdownState();
-              }}
+              on:mousedown={onTriggerMouseDown}
+              on:click={onTriggerClick}
               on:keydown={onTriggerKeydown}
               aria-disabled={!renderAsDropdown}
               data-testid="luigi-contextswitcher-button"
@@ -301,9 +310,8 @@
               aria-haspopup="true"
               tabindex="0"
               title={selectedLabel ? selectedLabel : config.defaultLabel}
-              on:click={() => {
-                if (renderAsDropdown) toggleDropdownState();
-              }}
+              on:mousedown={onTriggerMouseDown}
+              on:click={onTriggerClick}
               on:keydown={onTriggerKeydown}
               aria-disabled={!renderAsDropdown}
               data-testid="luigi-contextswitcher-button"
@@ -339,6 +347,7 @@
             {getTranslation}
             {isMobile}
             {isContextSwitcherDropdownShown}
+            {focusMenuOnOpen}
             on:onActionClick={onActionClick}
             on:goToOption={goToOption}
           />
@@ -379,6 +388,7 @@
             {getTranslation}
             {isMobile}
             {isContextSwitcherDropdownShown}
+            {focusMenuOnOpen}
             on:onActionClick={onActionClick}
             on:goToOption={goToOption}
           />

--- a/core/src/navigation/ContextSwitcher.svelte
+++ b/core/src/navigation/ContextSwitcher.svelte
@@ -44,8 +44,24 @@
   let popoverEl;
   let focusMenuOnOpen = 'first';
   let skipNextTriggerClick = false;
+  // Keep in sync with $desktopMaxWidth in core/src/styles/_variables.scss.
+  let isNarrowViewport =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(max-width: 899px)').matches
+      : false;
 
   onMount(async () => {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const mq = window.matchMedia('(max-width: 899px)');
+      const syncViewport = (event) => {
+        isNarrowViewport = event && typeof event.matches === 'boolean' ? event.matches : mq.matches;
+      };
+      if (mq.addEventListener) {
+        mq.addEventListener('change', syncViewport);
+      } else if (mq.addListener) {
+        mq.addListener(syncViewport);
+      }
+    }
     StateHelpers.doOnStoreChange(store, async () => {
       const contextSwitcherConfig = LuigiConfig.getConfigValue('navigation.contextSwitcher');
       contextSwitcherEnabled = !!contextSwitcherConfig;
@@ -205,12 +221,26 @@
   }
 
   function focusMenuItem(which) {
-    const items = DropdownKeyboardHelpers.getMenuItems(popoverEl);
+    const root = !isMobile ? document.getElementById('contextSwitcherPopover') || popoverEl : popoverEl;
+    const items = DropdownKeyboardHelpers.getMenuItems(root);
     if (!items.length) {
       return;
     }
     const index = which === 'last' ? items.length - 1 : 0;
     DropdownKeyboardHelpers.applyRovingTabindex(items, index);
+  }
+
+  function scheduleMenuFocus() {
+    if (isMobile) {
+      return;
+    }
+    tick().then(() => {
+      requestAnimationFrame(() => {
+        if (isDropdownOpen()) {
+          focusMenuItem(focusMenuOnOpen);
+        }
+      });
+    });
   }
 
   async function closeAndFocusTrigger() {
@@ -245,22 +275,23 @@
     }
     focusMenuOnOpen = 'first';
     toggleDropdownState();
+    scheduleMenuFocus();
   }
 
   function onTriggerKeydown(event) {
     DropdownKeyboardHelpers.handleTriggerKeydown(event, {
       isOpen: isDropdownOpen(),
       isDisabled: !renderAsDropdown || event.currentTarget.getAttribute('aria-disabled') === 'true',
-      isAnchor: event.currentTarget.tagName === 'A',
       onToggle: (focus) => {
         focusMenuOnOpen = focus || 'first';
-        if (event.currentTarget.tagName === 'A' && DropdownKeyboardHelpers.isActivationKey(event)) {
+        if (DropdownKeyboardHelpers.isActivationKey(event)) {
           skipNextTriggerClick = true;
           setTimeout(() => {
             skipNextTriggerClick = false;
-          }, 500);
+          }, 1000);
         }
         toggleDropdownState();
+        scheduleMenuFocus();
       },
       onFocusFirst: () => focusMenuItem('first'),
       onFocusLast: () => focusMenuItem('last'),
@@ -338,6 +369,7 @@
           aria-hidden={!(dropDownStates.contextSwitcherPopover || false)}
           id="contextSwitcherPopover"
           data-testid="luigi-contextswitcher-popover"
+          inert={dropDownStates.contextSwitcherPopover ? undefined : true}
           on:keydown={onPopoverKeydown}
         >
           <ContextSwitcherNav
@@ -361,7 +393,7 @@
     </div>
   {/if}
   <!-- MOBILE VERSION (fullscreen dialog): -->
-  {#if isMobile && dropDownStates.contextSwitcherPopover && renderAsDropdown}
+  {#if isMobile && isNarrowViewport && dropDownStates.contextSwitcherPopover && renderAsDropdown}
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div class="fd-dialog fd-dialog--active" role="presentation" on:click|stopPropagation={() => {}}>
       <div

--- a/core/src/navigation/ContextSwitcher.svelte
+++ b/core/src/navigation/ContextSwitcher.svelte
@@ -234,13 +234,38 @@
     if (isMobile) {
       return;
     }
+    const attempt = () => {
+      const popover = document.getElementById('contextSwitcherPopover');
+      if (popover) {
+        popover.removeAttribute('inert');
+      }
+      focusMenuItem(focusMenuOnOpen);
+    };
     tick().then(() => {
+      attempt();
       requestAnimationFrame(() => {
-        if (isDropdownOpen()) {
-          focusMenuItem(focusMenuOnOpen);
-        }
+        attempt();
+        setTimeout(attempt, 0);
       });
     });
+  }
+
+  function triggerKeyboardAction(node) {
+    node.addEventListener('keydown', onTriggerKeydown);
+    return {
+      destroy() {
+        node.removeEventListener('keydown', onTriggerKeydown);
+      }
+    };
+  }
+
+  function popoverKeyboardAction(node) {
+    node.addEventListener('keydown', onPopoverKeydown);
+    return {
+      destroy() {
+        node.removeEventListener('keydown', onPopoverKeydown);
+      }
+    };
   }
 
   async function closeAndFocusTrigger() {
@@ -327,7 +352,7 @@
               title={selectedLabel ? selectedLabel : config.defaultLabel}
               on:mousedown={onTriggerMouseDown}
               on:click={onTriggerClick}
-              on:keydown={onTriggerKeydown}
+              use:triggerKeyboardAction
               aria-disabled={!renderAsDropdown}
               data-testid="luigi-contextswitcher-button"
             >
@@ -340,6 +365,7 @@
             </a>
           {:else}
             <button
+              type="button"
               class="fd-button fd-button--transparent fd-button--menu fd-shellbar__button fd-shellbar__button--menu lui-ctx-switch-menu"
               aria-controls="contextSwitcherPopover"
               aria-expanded={dropDownStates.contextSwitcherPopover || false}
@@ -348,7 +374,7 @@
               title={selectedLabel ? selectedLabel : config.defaultLabel}
               on:mousedown={onTriggerMouseDown}
               on:click={onTriggerClick}
-              on:keydown={onTriggerKeydown}
+              use:triggerKeyboardAction
               aria-disabled={!renderAsDropdown}
               data-testid="luigi-contextswitcher-button"
             >
@@ -369,8 +395,7 @@
           aria-hidden={!(dropDownStates.contextSwitcherPopover || false)}
           id="contextSwitcherPopover"
           data-testid="luigi-contextswitcher-popover"
-          inert={dropDownStates.contextSwitcherPopover ? undefined : true}
-          on:keydown={onPopoverKeydown}
+          use:popoverKeyboardAction
         >
           <ContextSwitcherNav
             {actions}

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -24,9 +24,9 @@
   }
 </script>
 
-<nav class="fd-menu lui-ctx-switch-nav {isMobile ? 'fd-menu--mobile' : ''}">
+<div class="fd-menu lui-ctx-switch-nav {isMobile ? 'fd-menu--mobile' : ''}" role="menu">
   {#if actions && actions.length}
-    <ul class="fd-menu__list fd-menu__list--top">
+    <ul class="fd-menu__list fd-menu__list--top" role="none">
       {#each actions as node}
         {#if node.position === 'top' || !['top', 'bottom'].includes(node.position)}
           <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -36,7 +36,13 @@
             on:click={() => onActionClick(node)}
             data-testid={NavigationHelpers.getTestId(node)}
           >
-            <a href={getRouteLink(node)} on:click|preventDefault={() => {}} class="fd-menu__link">
+            <a
+              href={getRouteLink(node)}
+              on:click|preventDefault={() => {}}
+              class="fd-menu__link"
+              role="menuitem"
+              tabindex="-1"
+            >
               <span class="fd-menu__title">{$getTranslation(node.label)}</span>
             </a>
           </li>
@@ -44,7 +50,7 @@
       {/each}
     </ul>
   {/if}
-  <ul class="fd-menu__list" id="context_menu_middle">
+  <ul class="fd-menu__list" id="context_menu_middle" role="none">
     {#if options && options.length === 0 && isContextSwitcherDropdownShown}
       <li class="lui-contextswitcher-indicator">
         <div
@@ -79,6 +85,9 @@
                 }}
                 class="fd-menu__link {label === selectedLabel ? 'is-selected' : ''}"
                 title={label}
+                role="menuitem"
+                tabindex="-1"
+                aria-current={label === selectedLabel ? 'true' : undefined}
               >
                 <span class="fd-menu__title">{label}</span>
               </a>
@@ -89,7 +98,7 @@
     {/if}
   </ul>
   {#if actions && actions.length}
-    <ul class="fd-menu__list fd-menu__list--bottom">
+    <ul class="fd-menu__list fd-menu__list--bottom" role="none">
       {#each actions as node}
         {#if node.position === 'bottom'}
           <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -105,6 +114,8 @@
                 NavigationHelpers.handleNavAnchorClickedWithoutMetaKey(event);
               }}
               class="fd-menu__link"
+              role="menuitem"
+              tabindex="-1"
             >
               <span class="fd-menu__title">{$getTranslation(node.label)}</span>
             </a>
@@ -113,7 +124,7 @@
       {/each}
     </ul>
   {/if}
-</nav>
+</div>
 
 <style lang="scss">
   :global(.fd-popover__body) {

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -43,6 +43,10 @@
     if (!menuEl.getClientRects().length) {
       return false;
     }
+    const popover = document.getElementById('contextSwitcherPopover');
+    if (!popover || popover.getAttribute('aria-hidden') !== 'false') {
+      return false;
+    }
     const menuItems = DropdownKeyboardHelpers.getMenuItems(menuEl);
     if (!menuItems.length) {
       return false;
@@ -57,6 +61,10 @@
 
   function recaptureFocusFromTrigger() {
     if (!isContextSwitcherDropdownShown || isMobile) {
+      return;
+    }
+    const popover = document.getElementById('contextSwitcherPopover');
+    if (!popover || popover.getAttribute('aria-hidden') !== 'false') {
       return;
     }
     const trigger = document.querySelector('[data-testid="luigi-contextswitcher-button"]');

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { createEventDispatcher } from 'svelte';
-  import { NavigationHelpers } from '../utilities/helpers';
+  import { afterUpdate, createEventDispatcher, onDestroy } from 'svelte';
+  import { DropdownKeyboardHelpers, NavigationHelpers } from '../utilities/helpers';
 
   export let actions = [];
   export let config = {};
@@ -13,6 +13,11 @@
   export let getRouteLink;
   export let getTranslation;
   export let isContextSwitcherDropdownShown;
+  export let focusMenuOnOpen = 'first';
+
+  let menuEl;
+  let wasDropdownShown = false;
+  let focusTimeout;
 
   const dispatch = createEventDispatcher();
   export function onActionClick(node) {
@@ -22,9 +27,60 @@
   export function goToOption(option, selectedOption) {
     dispatch('goToOption', { option, selectedOption });
   }
+
+  function clearFocusTimeout() {
+    if (focusTimeout) {
+      clearTimeout(focusTimeout);
+      focusTimeout = undefined;
+    }
+  }
+
+  function tryFocusOpenItem() {
+    if (!isContextSwitcherDropdownShown) {
+      return true;
+    }
+    const menuItems = DropdownKeyboardHelpers.getMenuItems(menuEl);
+    if (!menuItems.length) {
+      return false;
+    }
+    if (menuItems.includes(document.activeElement)) {
+      wasDropdownShown = true;
+      return true;
+    }
+    const index = focusMenuOnOpen === 'last' ? menuItems.length - 1 : 0;
+    DropdownKeyboardHelpers.applyRovingTabindex(menuItems, index);
+    if (menuItems.includes(document.activeElement)) {
+      wasDropdownShown = true;
+      return true;
+    }
+    return false;
+  }
+
+  afterUpdate(() => {
+    if (!isContextSwitcherDropdownShown) {
+      wasDropdownShown = false;
+      clearFocusTimeout();
+      return;
+    }
+    if (wasDropdownShown) {
+      return;
+    }
+    // Labels render inside {#await}. Retry until a menuitem actually holds focus
+    // so the trigger click cannot steal it back.
+    const attempt = (remaining) => {
+      if (tryFocusOpenItem() || remaining <= 0) {
+        return;
+      }
+      focusTimeout = setTimeout(() => attempt(remaining - 1), 20);
+    };
+    clearFocusTimeout();
+    focusTimeout = setTimeout(() => attempt(25), 0);
+  });
+
+  onDestroy(clearFocusTimeout);
 </script>
 
-<div class="fd-menu lui-ctx-switch-nav {isMobile ? 'fd-menu--mobile' : ''}" role="menu">
+<div bind:this={menuEl} class="fd-menu lui-ctx-switch-nav {isMobile ? 'fd-menu--mobile' : ''}" role="menu">
   {#if actions && actions.length}
     <ul class="fd-menu__list fd-menu__list--top" role="none">
       {#each actions as node}

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { afterUpdate, createEventDispatcher, onDestroy } from 'svelte';
+  import { afterUpdate, createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { DropdownKeyboardHelpers, NavigationHelpers } from '../utilities/helpers';
 
   export let actions = [];
@@ -16,7 +16,6 @@
   export let focusMenuOnOpen = 'first';
 
   let menuEl;
-  let wasDropdownShown = false;
   let focusTimeout;
 
   const dispatch = createEventDispatcher();
@@ -35,49 +34,66 @@
     }
   }
 
-  function tryFocusOpenItem() {
-    if (!isContextSwitcherDropdownShown) {
-      return true;
+  function focusOpenItem() {
+    // Two ContextSwitcher instances share dropDownStates. The mobile copy
+    // must not steal focus from the desktop popover that the e2e asserts on.
+    if (!isContextSwitcherDropdownShown || !menuEl || isMobile) {
+      return false;
+    }
+    if (!menuEl.getClientRects().length) {
+      return false;
     }
     const menuItems = DropdownKeyboardHelpers.getMenuItems(menuEl);
     if (!menuItems.length) {
       return false;
     }
     if (menuItems.includes(document.activeElement)) {
-      wasDropdownShown = true;
       return true;
     }
     const index = focusMenuOnOpen === 'last' ? menuItems.length - 1 : 0;
     DropdownKeyboardHelpers.applyRovingTabindex(menuItems, index);
-    if (menuItems.includes(document.activeElement)) {
-      wasDropdownShown = true;
-      return true;
+    return menuItems.includes(document.activeElement);
+  }
+
+  function recaptureFocusFromTrigger() {
+    if (!isContextSwitcherDropdownShown || isMobile) {
+      return;
     }
-    return false;
+    const trigger = document.querySelector('[data-testid="luigi-contextswitcher-button"]');
+    if (document.activeElement === trigger) {
+      focusOpenItem();
+    }
   }
 
   afterUpdate(() => {
     if (!isContextSwitcherDropdownShown) {
-      wasDropdownShown = false;
       clearFocusTimeout();
       return;
     }
-    if (wasDropdownShown) {
-      return;
-    }
-    // Labels render inside {#await}. Retry until a menuitem actually holds focus
-    // so the trigger click cannot steal it back.
-    const attempt = (remaining) => {
-      if (tryFocusOpenItem() || remaining <= 0) {
+    clearFocusTimeout();
+    const started = Date.now();
+    const tick = () => {
+      if (!isContextSwitcherDropdownShown || Date.now() - started > 4000) {
         return;
       }
-      focusTimeout = setTimeout(() => attempt(remaining - 1), 20);
+      const menuItems = DropdownKeyboardHelpers.getMenuItems(menuEl);
+      if (!menuItems.length || !menuItems.includes(document.activeElement)) {
+        recaptureFocusFromTrigger();
+        focusOpenItem();
+        focusTimeout = setTimeout(tick, 50);
+      }
     };
-    clearFocusTimeout();
-    focusTimeout = setTimeout(() => attempt(25), 0);
+    focusTimeout = setTimeout(tick, 0);
   });
 
-  onDestroy(clearFocusTimeout);
+  onMount(() => {
+    document.addEventListener('focusin', recaptureFocusFromTrigger);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('focusin', recaptureFocusFromTrigger);
+    clearFocusTimeout();
+  });
 </script>
 
 <div bind:this={menuEl} class="fd-menu lui-ctx-switch-nav {isMobile ? 'fd-menu--mobile' : ''}" role="menu">

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -41,9 +41,10 @@
       return false;
     }
     const popover = document.getElementById('contextSwitcherPopover');
-    if (!popover || popover.getAttribute('aria-hidden') !== 'false') {
+    if (!popover || popover.getAttribute('aria-hidden') === 'true') {
       return false;
     }
+    popover.removeAttribute('inert');
     const menuItems = DropdownKeyboardHelpers.getMenuItems(menuEl);
     if (!menuItems.length) {
       return false;
@@ -61,11 +62,15 @@
       return;
     }
     const popover = document.getElementById('contextSwitcherPopover');
-    if (!popover || popover.getAttribute('aria-hidden') !== 'false') {
+    if (!popover || popover.getAttribute('aria-hidden') === 'true') {
       return;
     }
-    const trigger = document.querySelector('[data-testid="luigi-contextswitcher-button"]');
-    if (document.activeElement === trigger) {
+    popover.removeAttribute('inert');
+    const items = DropdownKeyboardHelpers.getMenuItems(menuEl);
+    if (!items.length) {
+      return;
+    }
+    if (!items.includes(document.activeElement)) {
       focusOpenItem();
     }
   }

--- a/core/src/navigation/ContextSwitcherNav.svelte
+++ b/core/src/navigation/ContextSwitcherNav.svelte
@@ -40,9 +40,6 @@
     if (!isContextSwitcherDropdownShown || !menuEl || isMobile) {
       return false;
     }
-    if (!menuEl.getClientRects().length) {
-      return false;
-    }
     const popover = document.getElementById('contextSwitcherPopover');
     if (!popover || popover.getAttribute('aria-hidden') !== 'false') {
       return false;

--- a/core/src/navigation/TopNav.svelte
+++ b/core/src/navigation/TopNav.svelte
@@ -617,7 +617,7 @@
                 <div
                   class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                   aria-controls="profilePopover"
-                  aria-expanded="true"
+                  aria-expanded={dropDownStates.profilePopover || false}
                   aria-haspopup="true"
                   title={userInfo.name || undefined}
                   role="button"
@@ -658,7 +658,7 @@
                   <div
                     class="fd-button fd-button--transparent fd-shellbar__button fd-user-menu__control"
                     aria-controls="profilePopover"
-                    aria-expanded="true"
+                    aria-expanded={dropDownStates.profilePopover || false}
                     aria-haspopup="true"
                     title={userInfo.name || undefined}
                     role="button"

--- a/core/src/utilities/helpers/dropdown-keyboard-helpers.js
+++ b/core/src/utilities/helpers/dropdown-keyboard-helpers.js
@@ -82,7 +82,7 @@ class DropdownKeyboardHelpersClass {
     }
   }
 
-  handleTriggerKeydown(event, { isOpen, isDisabled, isAnchor, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
+  handleTriggerKeydown(event, { isOpen, isDisabled, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
     if (isDisabled) {
       if (this.isActivationKey(event) || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault();
@@ -129,7 +129,7 @@ class DropdownKeyboardHelpersClass {
       return;
     }
 
-    if (this.isSpaceKey(event) && isAnchor && onToggle) {
+    if (this.isActivationKey(event) && onToggle) {
       event.preventDefault();
       onToggle();
     }

--- a/core/src/utilities/helpers/dropdown-keyboard-helpers.js
+++ b/core/src/utilities/helpers/dropdown-keyboard-helpers.js
@@ -82,7 +82,7 @@ class DropdownKeyboardHelpersClass {
     }
   }
 
-  handleTriggerKeydown(event, { isOpen, isDisabled, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
+  handleTriggerKeydown(event, { isOpen, isDisabled, isAnchor, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
     if (isDisabled) {
       if (this.isActivationKey(event) || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault();
@@ -129,7 +129,7 @@ class DropdownKeyboardHelpersClass {
       return;
     }
 
-    if (this.isActivationKey(event) && onToggle) {
+    if (this.isActivationKey(event) && isAnchor && onToggle) {
       event.preventDefault();
       onToggle();
     }

--- a/core/src/utilities/helpers/dropdown-keyboard-helpers.js
+++ b/core/src/utilities/helpers/dropdown-keyboard-helpers.js
@@ -1,0 +1,139 @@
+class DropdownKeyboardHelpersClass {
+  constructor() {
+    this.MENU_ITEM_SELECTOR = 'a.fd-menu__link';
+  }
+
+  isSpaceKey(event) {
+    return event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space';
+  }
+
+  isActivationKey(event) {
+    return event.key === 'Enter' || this.isSpaceKey(event);
+  }
+
+  getMenuItems(root) {
+    if (!root) {
+      return [];
+    }
+    return Array.from(root.querySelectorAll(this.MENU_ITEM_SELECTOR)).filter((item) => {
+      return item.getAttribute('aria-disabled') !== 'true' && !item.hasAttribute('disabled');
+    });
+  }
+
+  applyRovingTabindex(items, focusedIndex) {
+    items.forEach((item, index) => {
+      item.setAttribute('tabindex', index === focusedIndex ? '0' : '-1');
+    });
+    if (items[focusedIndex]) {
+      items[focusedIndex].focus();
+    }
+  }
+
+  nextIndex(currentIndex, length, direction) {
+    if (!length) {
+      return -1;
+    }
+    if (currentIndex < 0) {
+      return direction > 0 ? 0 : length - 1;
+    }
+    return (currentIndex + direction + length) % length;
+  }
+
+  handleMenuKeydown(event, { items = [], onEscape, onActivate } = {}) {
+    const currentIndex = items.indexOf(document.activeElement);
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.applyRovingTabindex(items, this.nextIndex(currentIndex, items.length, 1));
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.applyRovingTabindex(items, this.nextIndex(currentIndex, items.length, -1));
+      return;
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      this.applyRovingTabindex(items, 0);
+      return;
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      this.applyRovingTabindex(items, items.length - 1);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (onEscape) {
+        onEscape();
+      }
+      return;
+    }
+
+    if (this.isSpaceKey(event) && currentIndex >= 0 && onActivate) {
+      event.preventDefault();
+      onActivate(items[currentIndex]);
+    }
+  }
+
+  handleTriggerKeydown(event, { isOpen, isDisabled, isAnchor, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
+    if (isDisabled) {
+      if (this.isActivationKey(event) || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (event.repeat && this.isActivationKey(event)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      if (isOpen && onClose) {
+        event.preventDefault();
+        onClose();
+      }
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (isOpen) {
+        if (onFocusFirst) {
+          onFocusFirst();
+        }
+      } else if (onToggle) {
+        onToggle('first');
+      }
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (isOpen) {
+        if (onFocusLast) {
+          onFocusLast();
+        }
+      } else if (onToggle) {
+        onToggle('last');
+      }
+      return;
+    }
+
+    if (this.isSpaceKey(event) && isAnchor && onToggle) {
+      event.preventDefault();
+      onToggle();
+    }
+  }
+}
+
+export const DropdownKeyboardHelpers = new DropdownKeyboardHelpersClass();

--- a/core/src/utilities/helpers/dropdown-keyboard-helpers.js
+++ b/core/src/utilities/helpers/dropdown-keyboard-helpers.js
@@ -82,7 +82,7 @@ class DropdownKeyboardHelpersClass {
     }
   }
 
-  handleTriggerKeydown(event, { isOpen, isDisabled, isAnchor, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
+  handleTriggerKeydown(event, { isOpen, isDisabled, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
     if (isDisabled) {
       if (this.isActivationKey(event) || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault();
@@ -129,8 +129,9 @@ class DropdownKeyboardHelpersClass {
       return;
     }
 
-    if (this.isActivationKey(event) && isAnchor && onToggle) {
+    if (this.isActivationKey(event) && onToggle) {
       event.preventDefault();
+      event.stopPropagation();
       onToggle();
     }
   }

--- a/core/src/utilities/helpers/dropdown-keyboard-helpers.js
+++ b/core/src/utilities/helpers/dropdown-keyboard-helpers.js
@@ -3,12 +3,49 @@ class DropdownKeyboardHelpersClass {
     this.MENU_ITEM_SELECTOR = 'a.fd-menu__link';
   }
 
+  eventKey(event) {
+    if (event.key && event.key !== 'Unidentified') {
+      return event.key;
+    }
+    const code = event.code;
+    const which = event.which || event.keyCode;
+    if (code === 'Enter' || which === 13) {
+      return 'Enter';
+    }
+    if (code === 'Escape' || code === 'Esc' || which === 27) {
+      return 'Escape';
+    }
+    if (code === 'ArrowDown' || which === 40) {
+      return 'ArrowDown';
+    }
+    if (code === 'ArrowUp' || which === 38) {
+      return 'ArrowUp';
+    }
+    if (code === 'ArrowLeft' || which === 37) {
+      return 'ArrowLeft';
+    }
+    if (code === 'ArrowRight' || which === 39) {
+      return 'ArrowRight';
+    }
+    if (code === 'Home' || which === 36) {
+      return 'Home';
+    }
+    if (code === 'End' || which === 35) {
+      return 'End';
+    }
+    if (code === 'Space' || code === 'Spacebar' || which === 32) {
+      return ' ';
+    }
+    return event.key;
+  }
+
   isSpaceKey(event) {
-    return event.key === ' ' || event.key === 'Spacebar' || event.code === 'Space';
+    const key = this.eventKey(event);
+    return key === ' ' || key === 'Spacebar' || event.code === 'Space';
   }
 
   isActivationKey(event) {
-    return event.key === 'Enter' || this.isSpaceKey(event);
+    return this.eventKey(event) === 'Enter' || this.isSpaceKey(event);
   }
 
   getMenuItems(root) {
@@ -25,7 +62,7 @@ class DropdownKeyboardHelpersClass {
       item.setAttribute('tabindex', index === focusedIndex ? '0' : '-1');
     });
     if (items[focusedIndex]) {
-      items[focusedIndex].focus();
+      items[focusedIndex].focus({ preventScroll: true });
     }
   }
 
@@ -41,34 +78,35 @@ class DropdownKeyboardHelpersClass {
 
   handleMenuKeydown(event, { items = [], onEscape, onActivate } = {}) {
     const currentIndex = items.indexOf(document.activeElement);
+    const key = this.eventKey(event);
 
-    if (event.key === 'ArrowDown') {
+    if (key === 'ArrowDown') {
       event.preventDefault();
       event.stopPropagation();
       this.applyRovingTabindex(items, this.nextIndex(currentIndex, items.length, 1));
       return;
     }
 
-    if (event.key === 'ArrowUp') {
+    if (key === 'ArrowUp') {
       event.preventDefault();
       event.stopPropagation();
       this.applyRovingTabindex(items, this.nextIndex(currentIndex, items.length, -1));
       return;
     }
 
-    if (event.key === 'Home') {
+    if (key === 'Home') {
       event.preventDefault();
       this.applyRovingTabindex(items, 0);
       return;
     }
 
-    if (event.key === 'End') {
+    if (key === 'End') {
       event.preventDefault();
       this.applyRovingTabindex(items, items.length - 1);
       return;
     }
 
-    if (event.key === 'Escape') {
+    if (key === 'Escape') {
       event.preventDefault();
       if (onEscape) {
         onEscape();
@@ -83,8 +121,10 @@ class DropdownKeyboardHelpersClass {
   }
 
   handleTriggerKeydown(event, { isOpen, isDisabled, onToggle, onFocusFirst, onFocusLast, onClose } = {}) {
+    const key = this.eventKey(event);
+
     if (isDisabled) {
-      if (this.isActivationKey(event) || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      if (this.isActivationKey(event) || key === 'ArrowDown' || key === 'ArrowUp') {
         event.preventDefault();
       }
       return;
@@ -95,7 +135,7 @@ class DropdownKeyboardHelpersClass {
       return;
     }
 
-    if (event.key === 'Escape') {
+    if (key === 'Escape') {
       if (isOpen && onClose) {
         event.preventDefault();
         onClose();
@@ -103,7 +143,7 @@ class DropdownKeyboardHelpersClass {
       return;
     }
 
-    if (event.key === 'ArrowDown') {
+    if (key === 'ArrowDown') {
       event.preventDefault();
       event.stopPropagation();
       if (isOpen) {
@@ -116,7 +156,7 @@ class DropdownKeyboardHelpersClass {
       return;
     }
 
-    if (event.key === 'ArrowUp') {
+    if (key === 'ArrowUp') {
       event.preventDefault();
       event.stopPropagation();
       if (isOpen) {

--- a/core/src/utilities/helpers/index.js
+++ b/core/src/utilities/helpers/index.js
@@ -10,3 +10,4 @@ export * from './event-listener-helpers';
 export * from './storage-helper';
 export * from './usersetting-dialog-helpers';
 export * from './global-search-helpers';
+export * from './dropdown-keyboard-helpers';

--- a/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
+++ b/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
@@ -241,7 +241,7 @@ describe('Dropdown-keyboard-helpers', () => {
       assert.isTrue(toggled);
     });
 
-    it('toggles a button trigger on Space', () => {
+    it('does not toggle a button trigger on Space so the native click can run', () => {
       const trigger = document.createElement('button');
       document.body.appendChild(trigger);
       let toggled = false;
@@ -253,7 +253,7 @@ describe('Dropdown-keyboard-helpers', () => {
         }
       });
 
-      assert.isTrue(toggled);
+      assert.isFalse(toggled);
     });
 
     it('opens to the first item on ArrowDown and last item on ArrowUp', () => {
@@ -328,7 +328,7 @@ describe('Dropdown-keyboard-helpers', () => {
       assert.isTrue(event.defaultPrevented);
     });
 
-    it('toggles a button trigger on Enter', () => {
+    it('does not toggle a button trigger on Enter so the native click can run', () => {
       const trigger = document.createElement('button');
       document.body.appendChild(trigger);
       let toggled = false;
@@ -340,7 +340,7 @@ describe('Dropdown-keyboard-helpers', () => {
         }
       });
 
-      assert.isTrue(toggled);
+      assert.isFalse(toggled);
     });
 
     it('prevents activation keys on a disabled trigger', () => {

--- a/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
+++ b/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
@@ -241,7 +241,7 @@ describe('Dropdown-keyboard-helpers', () => {
       assert.isTrue(toggled);
     });
 
-    it('does not toggle a button trigger on Space so the native click can run', () => {
+    it('toggles a button trigger on Space', () => {
       const trigger = document.createElement('button');
       document.body.appendChild(trigger);
       let toggled = false;
@@ -253,7 +253,7 @@ describe('Dropdown-keyboard-helpers', () => {
         }
       });
 
-      assert.isFalse(toggled);
+      assert.isTrue(toggled);
     });
 
     it('opens to the first item on ArrowDown and last item on ArrowUp', () => {
@@ -311,19 +311,36 @@ describe('Dropdown-keyboard-helpers', () => {
       assert.isTrue(closed);
     });
 
-    it('does not toggle on Enter so the native control click can run', () => {
+    it('toggles an anchor trigger on Enter', () => {
       const trigger = document.createElement('a');
       document.body.appendChild(trigger);
       let toggled = false;
 
-      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Enter'), {
+      const event = dispatchKey(trigger, 'Enter');
+      DropdownKeyboardHelpers.handleTriggerKeydown(event, {
         isAnchor: true,
         onToggle: () => {
           toggled = true;
         }
       });
 
-      assert.isFalse(toggled);
+      assert.isTrue(toggled);
+      assert.isTrue(event.defaultPrevented);
+    });
+
+    it('toggles a button trigger on Enter', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      let toggled = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Enter'), {
+        isAnchor: false,
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isTrue(toggled);
     });
 
     it('prevents activation keys on a disabled trigger', () => {

--- a/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
+++ b/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
@@ -1,0 +1,382 @@
+import { assert } from 'chai';
+import { DropdownKeyboardHelpers } from '../../../src/utilities/helpers';
+
+const dispatchKey = (target, key, extra = {}) => {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...extra
+  });
+  target.dispatchEvent(event);
+  return event;
+};
+
+describe('Dropdown-keyboard-helpers', () => {
+  let root;
+  let items;
+
+  const renderMenu = (labels = ['Env 1', 'Env 2', 'Env 3']) => {
+    root = document.createElement('nav');
+    root.innerHTML = labels.map((label) => `<a class="fd-menu__link" href="#">${label}</a>`).join('');
+    document.body.appendChild(root);
+    items = DropdownKeyboardHelpers.getMenuItems(root);
+    return items;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('getMenuItems', () => {
+    it('returns menu links and skips disabled items', () => {
+      root = document.createElement('nav');
+      root.innerHTML = `
+        <a class="fd-menu__link" href="#">One</a>
+        <a class="fd-menu__link" href="#" aria-disabled="true">Disabled</a>
+        <a class="fd-menu__link" href="#" disabled>Also disabled</a>
+        <span class="fd-menu__link">Not a link</span>
+      `;
+      document.body.appendChild(root);
+
+      const result = DropdownKeyboardHelpers.getMenuItems(root);
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].textContent, 'One');
+    });
+
+    it('returns an empty array when root is missing', () => {
+      assert.deepEqual(DropdownKeyboardHelpers.getMenuItems(null), []);
+    });
+  });
+
+  describe('nextIndex', () => {
+    it('wraps forward and backward', () => {
+      assert.equal(DropdownKeyboardHelpers.nextIndex(0, 3, 1), 1);
+      assert.equal(DropdownKeyboardHelpers.nextIndex(2, 3, 1), 0);
+      assert.equal(DropdownKeyboardHelpers.nextIndex(0, 3, -1), 2);
+    });
+
+    it('starts at first or last when nothing is focused', () => {
+      assert.equal(DropdownKeyboardHelpers.nextIndex(-1, 3, 1), 0);
+      assert.equal(DropdownKeyboardHelpers.nextIndex(-1, 3, -1), 2);
+      assert.equal(DropdownKeyboardHelpers.nextIndex(-1, 0, 1), -1);
+    });
+  });
+
+  describe('applyRovingTabindex', () => {
+    it('does not throw when the focused index is out of range', () => {
+      renderMenu();
+
+      DropdownKeyboardHelpers.applyRovingTabindex(items, -1);
+
+      items.forEach((item) => {
+        assert.equal(item.getAttribute('tabindex'), '-1');
+      });
+    });
+  });
+
+  describe('handleMenuKeydown', () => {
+    it('moves focus with ArrowDown and ArrowUp', () => {
+      renderMenu();
+      items[0].focus();
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[0], 'ArrowDown'), { items });
+      assert.equal(document.activeElement, items[1]);
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[1], 'ArrowUp'), { items });
+      assert.equal(document.activeElement, items[0]);
+    });
+
+    it('moves to last item on ArrowUp when nothing is focused', () => {
+      renderMenu();
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(root, 'ArrowUp'), {
+        items
+      });
+
+      assert.equal(document.activeElement, items[2]);
+    });
+
+    it('moves to first and last items with Home and End', () => {
+      renderMenu();
+      items[1].focus();
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[1], 'End'), {
+        items
+      });
+      assert.equal(document.activeElement, items[2]);
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[2], 'Home'), {
+        items
+      });
+      assert.equal(document.activeElement, items[0]);
+    });
+
+    it('calls onEscape on Escape', () => {
+      renderMenu();
+      let called = false;
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[0], 'Escape'), {
+        items,
+        onEscape: () => {
+          called = true;
+        }
+      });
+
+      assert.isTrue(called);
+    });
+
+    it('does not throw on Escape when onEscape is omitted', () => {
+      renderMenu();
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[0], 'Escape'), { items });
+    });
+
+    it('accepts a missing options object', () => {
+      renderMenu();
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(root, 'ArrowDown'));
+    });
+
+    it('activates the focused item on Space', () => {
+      renderMenu();
+      items[1].focus();
+      let activated = null;
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(items[1], ' '), {
+        items,
+        onActivate: (item) => {
+          activated = item;
+        }
+      });
+
+      assert.equal(activated, items[1]);
+    });
+
+    it('does not activate when Space is pressed and no item is focused', () => {
+      renderMenu();
+      let activated = false;
+
+      DropdownKeyboardHelpers.handleMenuKeydown(dispatchKey(root, ' '), {
+        items,
+        onActivate: () => {
+          activated = true;
+        }
+      });
+
+      assert.isFalse(activated);
+    });
+
+    it('recognizes Space via event.code', () => {
+      renderMenu();
+      items[0].focus();
+      let activated = false;
+      const event = new KeyboardEvent('keydown', {
+        key: 'Unidentified',
+        code: 'Space',
+        bubbles: true,
+        cancelable: true
+      });
+
+      DropdownKeyboardHelpers.handleMenuKeydown(event, {
+        items,
+        onActivate: () => {
+          activated = true;
+        }
+      });
+
+      assert.isTrue(activated);
+    });
+  });
+
+  describe('handleTriggerKeydown', () => {
+    it('does not toggle a disabled trigger', () => {
+      const trigger = document.createElement('a');
+      document.body.appendChild(trigger);
+      let toggled = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, ' '), {
+        isDisabled: true,
+        isAnchor: true,
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isFalse(toggled);
+    });
+
+    it('ignores repeated activation keys', () => {
+      const trigger = document.createElement('a');
+      document.body.appendChild(trigger);
+      let toggled = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, ' ', { repeat: true }), {
+        isAnchor: true,
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isFalse(toggled);
+    });
+
+    it('toggles an anchor trigger on Space', () => {
+      const trigger = document.createElement('a');
+      document.body.appendChild(trigger);
+      let toggled = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, ' '), {
+        isAnchor: true,
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isTrue(toggled);
+    });
+
+    it('does not toggle a button trigger on Space so the native click can run', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      let toggled = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, ' '), {
+        isAnchor: false,
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isFalse(toggled);
+    });
+
+    it('opens to the first item on ArrowDown and last item on ArrowUp', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      const calls = [];
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowDown'), {
+        isOpen: false,
+        onToggle: (focus) => calls.push(focus)
+      });
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowUp'), {
+        isOpen: false,
+        onToggle: (focus) => calls.push(focus)
+      });
+
+      assert.deepEqual(calls, ['first', 'last']);
+    });
+
+    it('focuses first and last items with arrows when already open', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      let first = false;
+      let last = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowDown'), {
+        isOpen: true,
+        onFocusFirst: () => {
+          first = true;
+        }
+      });
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowUp'), {
+        isOpen: true,
+        onFocusLast: () => {
+          last = true;
+        }
+      });
+
+      assert.isTrue(first);
+      assert.isTrue(last);
+    });
+
+    it('closes an open menu on Escape', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      let closed = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Escape'), {
+        isOpen: true,
+        onClose: () => {
+          closed = true;
+        }
+      });
+
+      assert.isTrue(closed);
+    });
+
+    it('does not toggle on Enter so the native control click can run', () => {
+      const trigger = document.createElement('a');
+      document.body.appendChild(trigger);
+      let toggled = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Enter'), {
+        isAnchor: true,
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isFalse(toggled);
+    });
+
+    it('prevents activation keys on a disabled trigger', () => {
+      const trigger = document.createElement('a');
+      document.body.appendChild(trigger);
+      const event = dispatchKey(trigger, 'Enter');
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(event, {
+        isDisabled: true,
+        isAnchor: true,
+        onToggle: () => {}
+      });
+
+      assert.isTrue(event.defaultPrevented);
+    });
+
+    it('does not close on Escape when the menu is already closed', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      let closed = false;
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Escape'), {
+        isOpen: false,
+        onClose: () => {
+          closed = true;
+        }
+      });
+
+      assert.isFalse(closed);
+    });
+
+    it('prevents arrow keys on a disabled trigger', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      const down = dispatchKey(trigger, 'ArrowDown');
+      const up = dispatchKey(trigger, 'ArrowUp');
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(down, { isDisabled: true });
+      DropdownKeyboardHelpers.handleTriggerKeydown(up, { isDisabled: true });
+
+      assert.isTrue(down.defaultPrevented);
+      assert.isTrue(up.defaultPrevented);
+    });
+
+    it('does not throw when open-arrow callbacks are omitted', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowDown'), { isOpen: true });
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowUp'), { isOpen: true });
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowDown'), { isOpen: false });
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'ArrowUp'), { isOpen: false });
+      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Tab'));
+    });
+  });
+});

--- a/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
+++ b/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
@@ -241,7 +241,7 @@ describe('Dropdown-keyboard-helpers', () => {
       assert.isTrue(toggled);
     });
 
-    it('does not toggle a button trigger on Space so the native click can run', () => {
+    it('toggles a button trigger on Space', () => {
       const trigger = document.createElement('button');
       document.body.appendChild(trigger);
       let toggled = false;
@@ -253,7 +253,7 @@ describe('Dropdown-keyboard-helpers', () => {
         }
       });
 
-      assert.isFalse(toggled);
+      assert.isTrue(toggled);
     });
 
     it('opens to the first item on ArrowDown and last item on ArrowUp', () => {
@@ -326,21 +326,24 @@ describe('Dropdown-keyboard-helpers', () => {
 
       assert.isTrue(toggled);
       assert.isTrue(event.defaultPrevented);
+      assert.isTrue(event.cancelBubble);
     });
 
-    it('does not toggle a button trigger on Enter so the native click can run', () => {
+    it('toggles a button trigger on Enter', () => {
       const trigger = document.createElement('button');
       document.body.appendChild(trigger);
       let toggled = false;
+      const event = dispatchKey(trigger, 'Enter');
 
-      DropdownKeyboardHelpers.handleTriggerKeydown(dispatchKey(trigger, 'Enter'), {
+      DropdownKeyboardHelpers.handleTriggerKeydown(event, {
         isAnchor: false,
         onToggle: () => {
           toggled = true;
         }
       });
 
-      assert.isFalse(toggled);
+      assert.isTrue(toggled);
+      assert.isTrue(event.defaultPrevented);
     });
 
     it('prevents activation keys on a disabled trigger', () => {

--- a/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
+++ b/core/test/utilities/helpers/dropdown-keyboard-helpers.spec.js
@@ -346,6 +346,28 @@ describe('Dropdown-keyboard-helpers', () => {
       assert.isTrue(event.defaultPrevented);
     });
 
+    it('toggles a button trigger on Enter when only keyCode is set', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      let toggled = false;
+      const event = new KeyboardEvent('keydown', {
+        key: 'Unidentified',
+        keyCode: 13,
+        which: 13,
+        bubbles: true,
+        cancelable: true
+      });
+
+      DropdownKeyboardHelpers.handleTriggerKeydown(event, {
+        onToggle: () => {
+          toggled = true;
+        }
+      });
+
+      assert.isTrue(toggled);
+      assert.isTrue(event.defaultPrevented);
+    });
+
     it('prevents activation keys on a disabled trigger', () => {
       const trigger = document.createElement('a');
       document.body.appendChild(trigger);

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
@@ -551,6 +551,7 @@ describe('JS-TEST-APP 4', () => {
       cy.get('[data-testid="luigi-contextswitcher-button"]').click();
       cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'false');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
+      cy.get('#contextSwitcherPopover a.fd-menu__link').should('have.length.at.least', 2);
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
       cy.focused().type('{downArrow}');
       cy.get('#contextSwitcherPopover a.fd-menu__link').eq(1).should('have.focus');
@@ -568,6 +569,7 @@ describe('JS-TEST-APP 4', () => {
     it('closes on Escape and restores focus to the trigger', () => {
       cy.visitTestApp('/', newConfig);
       cy.get('[data-testid="luigi-contextswitcher-button"]').click();
+      cy.get('#contextSwitcherPopover a.fd-menu__link').should('have.length.at.least', 2);
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
       cy.focused().type('{esc}');
       cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'true');

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
@@ -250,6 +250,7 @@ describe('JS-TEST-APP 4', () => {
     it('Open user menu by pressing enter', () => {
       cy.visitTestAppLoggedIn('/', newConfig);
       cy.get('#profilePopover').should('have.attr', 'aria-hidden', 'true');
+      cy.get('.fd-user-menu__control').should('have.attr', 'aria-expanded', 'false');
       cy.get('body').click();
       cy.tab();
       cy.tab();
@@ -257,11 +258,13 @@ describe('JS-TEST-APP 4', () => {
       cy.tab();
       cy.get('.fd-user-menu__control').should('have.focus').type('{enter}');
       cy.get('#profilePopover').should('have.attr', 'aria-hidden', 'false');
+      cy.get('.fd-user-menu__control').should('have.attr', 'aria-expanded', 'true');
     });
 
     it('Open user menu by pressing space', () => {
       cy.visitTestAppLoggedIn('/', newConfig);
       cy.get('#profilePopover').should('have.attr', 'aria-hidden', 'true');
+      cy.get('.fd-user-menu__control').should('have.attr', 'aria-expanded', 'false');
       cy.get('body').click();
       cy.tab();
       cy.tab();
@@ -269,6 +272,7 @@ describe('JS-TEST-APP 4', () => {
       cy.tab();
       cy.get('.fd-user-menu__control').should('have.focus').type(' ');
       cy.get('#profilePopover').should('have.attr', 'aria-hidden', 'false');
+      cy.get('.fd-user-menu__control').should('have.attr', 'aria-expanded', 'true');
     });
   });
 
@@ -510,6 +514,65 @@ describe('JS-TEST-APP 4', () => {
       };
       cy.get('#app[configversion="header-a11y"]');
       cy.get('.fd-shellbar__branding').should('have.attr', 'aria-label', '*Test App*');
+    });
+  });
+
+  describe('Context switcher keyboard navigation', () => {
+    let newConfig;
+
+    beforeEach(() => {
+      newConfig = structuredClone(defaultLuigiConfig);
+      newConfig.navigation.addNavHrefs = true;
+      newConfig.navigation.nodes.push({
+        hideFromNav: true,
+        pathSegment: 'environments',
+        viewUrl: '/examples/microfrontends/multipurpose.html',
+        children: [
+          {
+            pathSegment: ':environmentId',
+            viewUrl: '/examples/microfrontends/multipurpose.html'
+          }
+        ]
+      });
+      newConfig.navigation.contextSwitcher = {
+        defaultLabel: 'Select Environment',
+        parentNodePath: '/environments',
+        lazyloadOptions: false,
+        options: [
+          { label: 'Environment 1', pathValue: 'env1' },
+          { label: 'Environment 2', pathValue: 'env2' }
+        ]
+      };
+    });
+
+    it('exposes expanded state and moves between options with arrow keys', () => {
+      cy.visitTestApp('/', newConfig);
+      cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'false');
+      cy.get('[data-testid="luigi-contextswitcher-button"]').click();
+      cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'false');
+      cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
+      cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
+      cy.focused().type('{downArrow}');
+      cy.get('#contextSwitcherPopover a.fd-menu__link').eq(1).should('have.focus');
+      cy.focused().type('{upArrow}');
+      cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
+    });
+
+    it('keeps the menu open after Enter on the trigger', () => {
+      cy.visitTestApp('/', newConfig);
+      cy.get('[data-testid="luigi-contextswitcher-button"]').focus().type('{enter}');
+      cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'false');
+      cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
+    });
+
+    it('closes on Escape and restores focus to the trigger', () => {
+      cy.visitTestApp('/', newConfig);
+      cy.get('[data-testid="luigi-contextswitcher-button"]').click();
+      cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
+      cy.focused().type('{esc}');
+      cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'true');
+      cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'false');
+      cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.focus');
     });
   });
 });

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
@@ -553,15 +553,17 @@ describe('JS-TEST-APP 4', () => {
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
       cy.get('#contextSwitcherPopover a.fd-menu__link').should('have.length.at.least', 2);
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
-      cy.focused().type('{downArrow}');
+      cy.focused().trigger('keydown', { key: 'ArrowDown', code: 'ArrowDown', which: 40 });
       cy.get('#contextSwitcherPopover a.fd-menu__link').eq(1).should('have.focus');
-      cy.focused().type('{upArrow}');
+      cy.focused().trigger('keydown', { key: 'ArrowUp', code: 'ArrowUp', which: 38 });
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
     });
 
     it('keeps the menu open after Enter on the trigger', () => {
       cy.visitTestApp('/', newConfig);
-      cy.get('[data-testid="luigi-contextswitcher-button"]').focus().type('{enter}');
+      cy.get('[data-testid="luigi-contextswitcher-button"]')
+        .focus()
+        .trigger('keydown', { key: 'Enter', code: 'Enter', which: 13 });
       cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'false');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
     });
@@ -571,7 +573,7 @@ describe('JS-TEST-APP 4', () => {
       cy.get('[data-testid="luigi-contextswitcher-button"]').click();
       cy.get('#contextSwitcherPopover a.fd-menu__link').should('have.length.at.least', 2);
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
-      cy.focused().type('{esc}');
+      cy.focused().trigger('keydown', { key: 'Escape', code: 'Escape', which: 27 });
       cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'true');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'false');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.focus');

--- a/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
+++ b/test/e2e-test-application/cypress/e2e/tests/0-js-test-app/js-test-app-a11y.cy.js
@@ -553,17 +553,16 @@ describe('JS-TEST-APP 4', () => {
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
       cy.get('#contextSwitcherPopover a.fd-menu__link').should('have.length.at.least', 2);
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
-      cy.focused().trigger('keydown', { key: 'ArrowDown', code: 'ArrowDown', which: 40 });
+      cy.focused().type('{downarrow}');
       cy.get('#contextSwitcherPopover a.fd-menu__link').eq(1).should('have.focus');
-      cy.focused().trigger('keydown', { key: 'ArrowUp', code: 'ArrowUp', which: 38 });
+      cy.focused().type('{uparrow}');
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
     });
 
     it('keeps the menu open after Enter on the trigger', () => {
       cy.visitTestApp('/', newConfig);
-      cy.get('[data-testid="luigi-contextswitcher-button"]')
-        .focus()
-        .trigger('keydown', { key: 'Enter', code: 'Enter', which: 13 });
+      cy.get('body').click();
+      cy.get('[data-testid="luigi-contextswitcher-button"]').focus().type('{enter}');
       cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'false');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'true');
     });
@@ -573,7 +572,7 @@ describe('JS-TEST-APP 4', () => {
       cy.get('[data-testid="luigi-contextswitcher-button"]').click();
       cy.get('#contextSwitcherPopover a.fd-menu__link').should('have.length.at.least', 2);
       cy.get('#contextSwitcherPopover a.fd-menu__link').first().should('have.focus');
-      cy.focused().trigger('keydown', { key: 'Escape', code: 'Escape', which: 27 });
+      cy.focused().type('{esc}');
       cy.get('#contextSwitcherPopover').should('have.attr', 'aria-hidden', 'true');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.attr', 'aria-expanded', 'false');
       cy.get('[data-testid="luigi-contextswitcher-button"]').should('have.focus');


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add keyboard support for the context switcher (Arrow Up/Down, Home/End, Escape, Enter/Space) so users can move between options without Tab
- Keep `aria-expanded` in sync on the context switcher trigger, including the `addNavHrefs` link trigger
- Remove the Enter/Space `keyup` handler that closed the menu again right after it opened
- Bind Fiori3 and Vega profile `aria-expanded` to the actual popover state instead of hardcoding `true`

This was developed with AI assistance (Cursor). The change is original to this codebase and follows the SAP AI contribution guideline.

**Related issue(s)**

No existing issue. Found while using the context switcher with keyboard: Down Arrow did not move to the next option, and Escape could interact badly with a profile control that stayed `aria-expanded="true"` while closed.

## Test plan
- [ ] Open the context switcher with Enter or click; first option is focused
- [ ] Arrow Down/Up move between options; Home/End jump to first/last
- [ ] Enter on the trigger does not immediately close the menu
- [ ] Escape closes the menu and returns focus to the trigger
- [ ] Profile control `aria-expanded` is `false` when closed and `true` when open